### PR TITLE
Ability to read from a config file and to customize colors.

### DIFF
--- a/bin/madge
+++ b/bin/madge
@@ -6,6 +6,7 @@
  * Module dependencies
  */
 var fs = require('fs'),
+	path = require('path'),
 	version = require('../lib/version'),
 	program = require('commander'),
 	madge = require('../index');
@@ -25,6 +26,7 @@ program
 	.option('-b, --break-on-error', 'break on parse errors & missing modules', false)
 	.option('-n, --no-colors', 'skip colors in output and images', false)
 	.option('-r, --read', 'skip scanning folders and read JSON from stdin')
+    .option('-c, --config <filename>', 'provide a config file')
 	.parse(process.argv);
 
 if (!program.args.length && !program.read) {
@@ -37,6 +39,21 @@ var src = program.args;
 if (program.read) {
 	src = JSON.parse(fs.readFileSync('/dev/stdin').toString());
 }
+
+// Check config file
+if (program.config) {
+    if (path.existsSync(program.config)) {
+		var configOptions = JSON.parse(fs.readFileSync(program.config, 'utf8'));
+		// Duck punch the program with the new options
+		// Config file take precedence
+		for (var k in configOptions) {
+			if (configOptions.hasOwnProperty(k)) {
+				program[k] = configOptions[k];
+			}
+		}
+    }
+}
+
 
  // Start parsing
 var res = madge(src, {
@@ -70,7 +87,10 @@ if (program.summary) {
 } else if (program.image) {
 	res.image({
 		colors: program.colors,
-		layout: program.layout
+		layout: program.layout,
+		fontFace: program.font,
+		fontSize: program.fontSize,
+		imageColors: program.imageColors
 	}, function (image) {
 		fs.writeFile(program.image, image, function (err) {
 			if (err) {

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -23,8 +23,8 @@ function nodeColor(node, color) {
  *
  * @param  {Object} node
  */
-function noDependencyNode(node) {
-	nodeColor(node, '#cfffac');
+function noDependencyNode(node, color) {
+	nodeColor(node, color || '#cfffac');
 }
 
 /**
@@ -52,23 +52,24 @@ module.exports.image = function (modules, opts, callback) {
 	checkGraphvizInstalled();
 
 	var nodes = {},
-		circular = require('./analysis/circular')(modules);
+		circular = require('./analysis/circular')(modules),
+        colors = opts.imageColors || {};
 
 	Object.keys(modules).forEach(function (id) {
 
 		nodes[id] = nodes[id] || g.addNode(id);
 		if (opts.colors && modules[id]) {
 			if (!modules[id].length) {
-				noDependencyNode(nodes[id]);
+				noDependencyNode(nodes[id], colors.noDependencies);
 			} else if (circular[id]) {
-				nodeColor(nodes[id], '#ff6c60');
+				nodeColor(nodes[id], (colors.circular || '#ff6c60'));
 			}
 		}
 
 		modules[id].forEach(function (depId) {
 			nodes[depId] = nodes[depId] || g.addNode(depId);
 			if (opts.colors && !modules[depId]) {
-				noDependencyNode(nodes[depId]);
+				noDependencyNode(nodes[depId], colors.noDependencies);
 			}
 			g.addEdge(nodes[id], nodes[depId]);
 		});
@@ -80,10 +81,14 @@ module.exports.image = function (modules, opts, callback) {
 		'G' : {
 			'layout': opts.layout || 'dot',
 			'overlap': false,
-			'bgcolor': opts.colors ? '#000000' : '#ffffff'
+			'bgcolor': opts.colors ? (colors.bgcolor || '#000000') : '#ffffff'
 		},
-		'E' : opts.colors ? {'color': '#4a4a4a'} : {},
-		'N' : opts.colors ? {'color': '#c6c5fe', 'fontcolor': '#c6c5fe'} : {}
+		'E' : opts.colors ? {'color': (colors.arrows || '#4a4a4a') } : {},
+		'N' : opts.colors ? {
+            'color': (colors.dependencies || '#c6c5fe'),
+            'fontcolor': (colors.fontColor || colors.dependencies || '#c6c5fe'),
+            'fontname' : colors.fontFace,
+        } : {}
 	}, callback);
 
 };


### PR DESCRIPTION
Given a `JSON` file using the `--config` parameter, the madge binary
will read and parse the JSON file and use the given options.
e.g.:

```
{
    "format": "amd",
    "image": "dependency_map.png"
    "fontFace": "Helvetica",
    "fontSize": "14px",
    "imageColors": {
        "noDependencies" : "#0000ff",
        "dependencies" : "#00ff00",
        "circular" : "#bada55",
        "arrows" : "#bada55",
        "bgcolor": "#ffffff"
    }
}
```

this is the same than the following command (except the customization
part):

```
madge -f amd -i dependency_map.png src_folder/
```

except that now, the command becomes:

```
madge --config config/madge.json src_folder/
```

At the same time, throught the file, becomes possible to customize the
output colors, font and font size.

It's the first time, I'm using the graphviz, so I couldn't find a way on how to
turn on the antialiasing option, but that would also be a really nice feature.

This request comes at the fact, that I really wanted to customize the colors,
without resorting to a graphic editing software. 

Thanks for this awesome package, it's probably the most useful thing after
modules in Javascript! ;)
