### PR TITLE
Using require() to get version number instead of version.js

### DIFF
--- a/bin/madge
+++ b/bin/madge
@@ -6,7 +6,7 @@
  * Module dependencies
  */
 var fs = require('fs'),
-	version = require('../lib/version'),
+	version = require('../package.json').version,
 	program = require('commander'),
 	madge = require('../lib/madge');
 

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,1 +1,0 @@
-module.exports = JSON.parse(require('fs').readFileSync(__dirname + '/../package.json')).version;


### PR DESCRIPTION
This means that we no longer need version.js.
