### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,12 @@ Options object passed used in the constructor.
 
 #### .tree
 
-Dependency tree object.
+Dependency tree object. Can be overwritten with an object in the format:
+
+	{
+	     'module1': [ 'dep1a', 'dep1b' ],
+	     'module2': ['dep2a']
+	}
 
 #### .obj()
 


### PR DESCRIPTION
Added details of the structure of the .tree property

The project I'm working on uses a weird, custom-built dependency loader so I can't run madge directly on my src folder. What I have done is generate an object listing all the dependencies. After hacking around I found I could overwrite the .tree property and madge works fine, so I thought it'd be useful to document what structure the .tree object should take.
