### PR TITLE
adding the ability to know if there are requires that can't be parsed

### DIFF
--- a/lib/parse/amd.js
+++ b/lib/parse/amd.js
@@ -85,7 +85,7 @@ AMD.prototype.parseFile = function (filename) {
 				}
 			}, this);
 
-			return dependencies;
+			return {dependencies: dependencies, unresolved: []}; // all dependencies will be resolved for amd
 		}
 	} catch (e) {
 		if (this.opts.breakOnError) {

--- a/lib/parse/base.js
+++ b/lib/parse/base.js
@@ -146,7 +146,8 @@ Base.prototype.sortDependencies = function () {
 	var self = this;
 
 	this.tree = Object.keys(this.tree).sort().reduce(function (acc, id) {
-		(acc[id] = self.tree[id]).sort();
+		acc[id] = self.tree[id]
+        acc[id].dependencies.sort();
 		return acc;
 	}, {});
 };

--- a/lib/parse/cjs.js
+++ b/lib/parse/cjs.js
@@ -49,7 +49,8 @@ CJS.prototype.parseFile = function (filename) {
 				src = this.getFileSource(filename);
 
 			if (src.indexOf('require(') >= 0) {
-				detective(src).map(function (id) {
+				var requires = detective.find(src);
+				requires.strings.map(function (id) {
 					var depFilename = this.resolve(path.dirname(filename), id);
 					if (depFilename) {
 						return this.normalize(depFilename);
@@ -60,7 +61,7 @@ CJS.prototype.parseFile = function (filename) {
 					}
 				}, this);
 
-				return dependencies;
+				return {dependencies: dependencies, unresolved: requires.expressions};
 			}
 		}
 	} catch (e) {


### PR DESCRIPTION
Solves this issue: https://github.com/pahen/madge/issues/14 . Note that this is a breaking change, since this requires another set of results to be added to the return value of madge parsing. I need to use this on a project I'm working on, so I couldn't wait for comment, but please give me feedback and I'll tweak it as needed.
