### PR TITLE
using forward slashes on windows

### DIFF
--- a/lib/parse/amd.js
+++ b/lib/parse/amd.js
@@ -31,7 +31,7 @@ util.inherits(AMD, Base);
  * @return {String}
  */
 AMD.prototype.normalize = function (filename) {
-	var id = path.relative(this.baseDir, filename).replace(this.extRegEx, '');
+	var id = path.relative(this.baseDir, filename).replace(this.extRegEx, '').replace(/\\/g, '/');
 
 	try {
 

--- a/lib/parse/base.js
+++ b/lib/parse/base.js
@@ -79,7 +79,7 @@ Base.prototype.resolveTargets = function (sources) {
  * @return {String}
  */
 Base.prototype.normalize = function (filename) {
-	return path.relative(this.baseDir, filename).replace(this.extRegEx, '');
+	return path.relative(this.baseDir, filename).replace(this.extRegEx, '').replace(/\\/g, '/');
 };
 
 /**

--- a/lib/parse/cjs.js
+++ b/lib/parse/cjs.js
@@ -32,7 +32,7 @@ util.inherits(CJS, Base);
 CJS.prototype.normalize = function (filename) {
 	if (filename.charAt(0) !== '/') {
 		// a core module (not mapped to a file)
-		return filename;
+		return filename.replace(/\\/g, '/');
 	}
 	return Base.prototype.normalize.apply(this, arguments);
 };


### PR DESCRIPTION
This changeset fixes three failing tests on windows. There are more failing tests, but they come from the commondir-library and should be fixed there instead. This is related to Issue #20
