### PR TITLE
Implement requirejs path * configuration

### DIFF
--- a/lib/cyclic.js
+++ b/lib/cyclic.js
@@ -40,6 +40,12 @@ function resolver(id, modules, circular, resolved, unresolved) {
 			}
 		});
 	}
+	else{
+		// catch casing typos
+		// in this case the module might gets loaded by the browser, and when it contains circular dependencies
+		// the resolver cant find the chain of deps and cant find the circulars.
+		circular.push(getPath(id, unresolved));
+	}
 
 	resolved[id] = true;
 	unresolved[id] = false;

--- a/lib/madge.js
+++ b/lib/madge.js
@@ -29,6 +29,52 @@ function mergeTrees(a, b) {
 		});
 	});
 }
+/**
+ * Walks the dependency array and remaps entries when these match
+ *
+ * @param {Object} tree
+ * @param {Object} map
+ * @param {String} treeKey
+ */
+function remapDepArray(tree,map,treeKey){
+	var lookup = {};
+	var treeDepArray = tree[treeKey];
+
+	treeDepArray.forEach(function(dep){
+		lookup[dep] = true;
+	});
+	treeDepArray.forEach(function(dep,i){
+		var mappedDep = map[dep];
+		if(mappedDep && !lookup[mappedDep]){
+			lookup[mappedDep] = true;
+			treeDepArray[i] = mappedDep;
+		}
+	});
+}
+
+/**
+ * Walks the tree to search for entries and its dependencies for mapped names
+ * and replace them with the mapped directory
+ *
+ * @param tree
+ * @param map
+ */
+function convertMap(tree, map){
+	Object.keys(tree).forEach(function(treeKey){
+		var mappedTreeKey = map[treeKey];
+		if (mappedTreeKey){
+			tree[mappedTreeKey] = tree[treeKey] || [];
+			if (mappedTreeKey !== treeKey){
+				delete tree[treeKey];
+			}
+
+			remapDepArray(tree,map,mappedTreeKey);
+		}
+		else{
+			remapDepArray(tree,map,treeKey);
+		}
+	});
+}
 
 /**
  * Helper for re-mapping path-refs to id-refs that are specified in RequireJS' path config.
@@ -44,7 +90,6 @@ function convertPathsToIds(deps, pathDefs, baseDir) {
 	} else {
 		baseDir  = '';
 	}
-
 	Object.keys(pathDefs).forEach(function (id) {
 		path = pathDefs[id];
 
@@ -123,7 +168,6 @@ function Madge(src, opts) {
 	if (typeof(src) === 'string') {
 		src = [src];
 	}
-
 	if (src && src.length) {
 		tree = this.parse(src);
 	}
@@ -131,10 +175,12 @@ function Madge(src, opts) {
 	if (this.opts.requireConfig) {
 		var baseDir = src.length ? src[0].replace(/\\/g, '/') : '';
 		baseDir = requirejs.getBaseUrlFromConfig(this.opts.requireConfig, baseDir);
+
+		baseDir = "";
 		convertPathsToIds(tree, requirejs.getPathsFromConfig(this.opts.requireConfig, this.opts.exclude), baseDir);
 		mergeTrees(tree, requirejs.getShimDepsFromConfig(this.opts.requireConfig, this.opts.exclude));
+		convertMap(tree,requirejs.getMapsFromConfig(this.opts.requireConfig, this.opts.exclude)); // XTA ADDED
 	}
-
 	this.tree = tree;
 }
 

--- a/lib/requirejs.js
+++ b/lib/requirejs.js
@@ -58,6 +58,29 @@ module.exports.getPathsFromConfig = function (filename, exclude) {
 };
 
 /**
+ * Read * map definitions from RequireJS config.
+ *
+ * @param  {String} filename
+ * @param  {String} [exclude]
+ * @return {Object}
+ */
+module.exports.getMapsFromConfig = function (filename, exclude) {
+	var map = {},
+		config = parse.findConfig(filename, fs.readFileSync(filename, 'utf8')),
+		excludeRegex = exclude ? new RegExp(exclude) : false,
+		isIncluded = function (key) {
+			return !(excludeRegex && key.match(excludeRegex));
+		};
+
+	if (config.map && config.map["*"]) {
+		Object.keys(config.map["*"]).filter(isIncluded).forEach(function(shortName) {
+			map[shortName] = config.map["*"][shortName];
+		});
+	}
+	return map;
+};
+
+/**
  * Read baseUrl from RequireJS config.
  * @param  {String} filename
  * @param  {String} srcBaseDir


### PR DESCRIPTION
I am using the require.config.path list to map module names to filenames. When the project uses module names as well as file names madge cant find circular dependencies very well.

This change rewrites all found module names in the tree to the filename. Currently it is doing that for map["*"]

example:

```javascript
require.config({
    baseUrl : 'js',
    map:{
         "*":{
            "moduleName":"util/blah/moduleName"
        }
    }
});
```
