### PR TITLE
upgrade deps, fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "madge",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": "Patrik Henningsson <patrik.henningsson@gmail.com>",
   "repository": "git://github.com/pahen/node-madge",
   "homepage": "https://github.com/pahen/node-madge",
@@ -32,16 +32,16 @@
   "dependencies": {
     "amdetective": "0.0.2",
     "coffee-script": "1.3.3",
-    "colors": "0.6.0-1",
-    "commander": "1.0.0",
-    "commondir": "0.0.1",
-    "detective": "0.1.1",
-    "detective-es6": "1.1.0",
-    "graphviz": "0.0.7",
-    "react-tools": "0.12.1",
-    "resolve": "0.2.3",
-    "uglify-js": "1.2.6",
-    "walkdir": "0.0.5"
+    "colors": "1.1.2",
+    "commander": "2.8.1",
+    "commondir": "1.0.1",
+    "detective": "4.1.1",
+    "detective-es6": "1.1.2",
+    "graphviz": "0.0.8",
+    "react-tools": "0.13.3",
+    "resolve": "1.1.6",
+    "uglify-js": "1.3.5",
+    "walkdir": "0.0.10"
   },
   "devDependencies": {
     "grunt": "0.4.4",

--- a/test/files/cjs/coffeescript/a.coffee
+++ b/test/files/cjs/coffeescript/a.coffee
@@ -1,3 +1,3 @@
-b = require './b'
+b = require 'b'
 
 module.exports = 'A'

--- a/test/pluggable.js
+++ b/test/pluggable.js
@@ -9,7 +9,7 @@ describe('Madge', function () {
 			var idAdd = "";
 			var opts = {};
 			opts.onParseFile = function(obj) {
-				var arr = obj.filename.split('/');
+				var arr = obj.filename.replace(/\\/g, '/').split('/');
 				fileAdd += arr[arr.length-1];
 			};
 			opts.onAddModule = function(obj) {
@@ -26,7 +26,7 @@ describe('Madge', function () {
 			var idAdd = "";
 			var opts = {};
 			opts.onParseFile = function(obj) {
-				var arr = obj.filename.split('/');
+				var arr = obj.filename.replace(/\\/g, '/').split('/');
 				fileAdd += arr[arr.length-1];
 			};
 			opts.onAddModule = function(obj) {


### PR DESCRIPTION
I upgraded most dependencies to newest version (except `coffee-script` and `ugflify-js`).
When I tested it, the coffee-script test failed:

```
  1) module format (CommonJS) should compile coffeescript on-the-fly:

      AssertionError: expected Object { a: Array [ './b' ], b: Array [] } to equal Object { a: Array [ '../node_modules/b' ], b: Array [] } (at a -> '0', A has './b' and B has '../node_modules/b')
      + expected - actual

       {
         "a": [
      +    "../node_modules/b"
      -    "./b"
         ],
         "b": []
       }
```

However, if you do `require('./b')` it should require `b` from the same folder, and not from `node_modules` as far as I know. So I simply changed the test file.

Also, Windows uses `\` instead of `/` for paths.