### PR TITLE
2 extra features: aliases and squashing

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -44,6 +44,7 @@
 	"predef" : [
 		"define",
 		"describe",
-		"it"
+		"it",
+		"Set"
 	]
 }

--- a/bin/madge
+++ b/bin/madge
@@ -30,7 +30,7 @@ program
 	.option('-O, --optimized', 'if given file is optimized with r.js', false)
 	.option('-N, --find-nested-dependencies', 'find nested dependencies in AMD modules', false)
 	.option('-M, --main-require-module <name>', 'name of the primary RequireJS module, if it\'s included with `require()`', '')
-	.option('-S, --squash <regex>', 'squash dependencies matching regex', '')
+	.option('-S, --squash <regex>', 'simplify dependency graph by squashing dependencies matching regex; e.g. C depends on B depends on A, squash B, results in C depends on A', '')
 	.option('-j --json', 'output dependency tree in json')
 	.option('-p --paths <directory>', 'additional comma separated paths to search for dependencies (CJS only)', '')
 	.option('-e --extensions <list>', 'comma separated string of valid file extensions', 'js,coffee')

--- a/bin/madge
+++ b/bin/madge
@@ -31,6 +31,7 @@ program
 	.option('-N, --find-nested-dependencies', 'find nested dependencies in AMD modules', false)
 	.option('-M, --main-require-module <name>', 'name of the primary RequireJS module, if it\'s included with `require()`', '')
 	.option('-S, --squash <regex>', 'simplify dependency graph by squashing dependencies matching regex; e.g. C depends on B depends on A, squash B, results in C depends on A', '')
+	.option('-a, --aliases <string>', 'aliases as comma separated list; e.g. ', 'A:A/index,B:B/index')
 	.option('-j --json', 'output dependency tree in json')
 	.option('-p --paths <directory>', 'additional comma separated paths to search for dependencies (CJS only)', '')
 	.option('-e --extensions <list>', 'comma separated string of valid file extensions', 'js,coffee')
@@ -83,7 +84,8 @@ function run() {
 		paths: program.paths ? program.paths.split(',') : undefined,
 		extensions: program.extensions.split(',').map(function (str) { return '.' + str; }),
 		findNestedDependencies: program.findNestedDependencies,
-		squash: program.squash
+		squash: program.squash,
+		aliases: program.aliases ? program.aliases.split(',').map(function(pair) {return pair.split(':');}) : []
 	});
 
 	// Ouput summary

--- a/bin/madge
+++ b/bin/madge
@@ -30,6 +30,7 @@ program
 	.option('-O, --optimized', 'if given file is optimized with r.js', false)
 	.option('-N, --find-nested-dependencies', 'find nested dependencies in AMD modules', false)
 	.option('-M, --main-require-module <name>', 'name of the primary RequireJS module, if it\'s included with `require()`', '')
+	.option('-S, --squash <regex>', 'squash dependencies matching regex', '')
 	.option('-j --json', 'output dependency tree in json')
 	.option('-p --paths <directory>', 'additional comma separated paths to search for dependencies (CJS only)', '')
 	.option('-e --extensions <list>', 'comma separated string of valid file extensions', 'js,coffee')
@@ -81,7 +82,8 @@ function run() {
 		mainRequireModule: program.mainRequireModule,
 		paths: program.paths ? program.paths.split(',') : undefined,
 		extensions: program.extensions.split(',').map(function (str) { return '.' + str; }),
-		findNestedDependencies: program.findNestedDependencies
+		findNestedDependencies: program.findNestedDependencies,
+		squash: program.squash
 	});
 
 	// Ouput summary

--- a/bin/madge
+++ b/bin/madge
@@ -31,7 +31,7 @@ program
 	.option('-N, --find-nested-dependencies', 'find nested dependencies in AMD modules', false)
 	.option('-M, --main-require-module <name>', 'name of the primary RequireJS module, if it\'s included with `require()`', '')
 	.option('-S, --squash <regex>', 'simplify dependency graph by squashing dependencies matching regex; e.g. C depends on B depends on A, squash B, results in C depends on A', '')
-	.option('-a, --aliases <string>', 'aliases as comma separated list; e.g. ', 'A:A/index,B:B/index')
+	.option('-a, --aliases <string>', 'aliases as comma separated list; e.g. A:A/index,B:B/index', '')
 	.option('-j --json', 'output dependency tree in json')
 	.option('-p --paths <directory>', 'additional comma separated paths to search for dependencies (CJS only)', '')
 	.option('-e --extensions <list>', 'comma separated string of valid file extensions', 'js,coffee')

--- a/lib/madge.js
+++ b/lib/madge.js
@@ -197,9 +197,9 @@ Madge.prototype.depends = function (id) {
 };
 
 /**
- *
- * @param  {Array|Object} src
- * @return {Object}
+ * Remove intermediate dependencies that match squash_regex
+ * @param  {Array|Object} tree 	The dependency tree
+ * @param  {Regex string} squash_regex	Remove modules that match this regex
  */
 var squashTree = function(tree, squash_regex) {
 	var visited = new Set();

--- a/lib/madge.js
+++ b/lib/madge.js
@@ -232,10 +232,12 @@ var squashTree = function(tree, squash_regex) {
 var squashSubTree = function(tree, module, visited, squash_regex) {
 	if(visited.has(module)) return;
 	visited.add(module);
+	var orig_deps = tree[module];	//handle circular dependencies
+	tree[module] = [];
 	var regex = new RegExp(squash_regex);
-	if (tree[module]) {
+	if (orig_deps) {
 		var deps = new Set();
-		tree[module].forEach(function (dep) {
+		orig_deps.forEach(function (dep) {
 			if(dep.match(regex)) {
 				squashSubTree(tree, dep, visited, squash_regex);
 				if(tree[dep]) {

--- a/lib/madge.js
+++ b/lib/madge.js
@@ -230,7 +230,9 @@ var squashTree = function(tree, squash_regex) {
 };
 
 var squashSubTree = function(tree, module, visited, squash_regex) {
-	if(visited.has(module)) return;
+	if(visited.has(module)) {
+		return;
+	}
 	visited.add(module);
 	var orig_deps = tree[module];	//handle circular dependencies
 	tree[module] = [];

--- a/lib/madge.js
+++ b/lib/madge.js
@@ -128,6 +128,10 @@ function Madge(src, opts) {
 		tree = this.parse(src);
 	}
 
+	if (this.opts.aliases) {
+		addAliases(tree, this.opts.aliases);
+	}
+
 	if (this.opts.squash) {
 		squashTree(tree, this.opts.squash);
 	}
@@ -194,6 +198,17 @@ Madge.prototype.depends = function (id) {
 			}, false);
 		}
 	}, this);
+};
+
+/**
+ * Add aliases
+ * @param  {Array|Object} tree 	The dependency tree
+ * @param  {Array|pair of strings} aliases	Pairs of alias definitions
+ */
+var addAliases = function(tree, aliases) {
+	aliases.forEach(function(pair) {
+		tree[pair[0]] = [pair[1]];
+	});
 };
 
 /**

--- a/lib/madge.js
+++ b/lib/madge.js
@@ -128,6 +128,10 @@ function Madge(src, opts) {
 		tree = this.parse(src);
 	}
 
+	if (this.opts.squash) {
+		squashTree(tree, this.opts.squash);
+	}
+
 	if (this.opts.requireConfig) {
 		var baseDir = src.length ? src[0].replace(/\\/g, '/') : '';
 		baseDir = requirejs.getBaseUrlFromConfig(this.opts.requireConfig, baseDir);
@@ -190,6 +194,44 @@ Madge.prototype.depends = function (id) {
 			}, false);
 		}
 	}, this);
+};
+
+/**
+ *
+ * @param  {Array|Object} src
+ * @return {Object}
+ */
+var squashTree = function(tree, squash_regex) {
+	var visited = new Set();
+	var regex = new RegExp(squash_regex);
+	Object.keys(tree).forEach(function (module) {
+		squashSubTree(tree, module, visited, squash_regex);
+	}, this);
+	Object.keys(tree).forEach(function (module) {
+		if(module.match(regex)) {
+			delete tree[module];
+		}
+	}, this);
+};
+
+var squashSubTree = function(tree, module, visited, squash_regex) {
+	if(visited.has(module)) return;
+	visited.add(module);
+	var regex = new RegExp(squash_regex);
+	if (tree[module]) {
+		var deps = new Set();
+		tree[module].forEach(function (dep) {
+			if(dep.match(regex)) {
+				squashSubTree(tree, dep, visited, squash_regex);
+				if(tree[dep]) {
+					tree[dep].forEach(function (d) {deps.add(d);});
+				}
+			} else {
+				deps.add(dep);
+			}
+		}, false);
+		tree[module] = Array.from(deps);
+	}
 };
 
 /**


### PR DESCRIPTION
It is now possible to define aliases (as used in webpack for instance). E.g. library 'A' aliases 'libs/A/src/index'

Squashing allows the dependency graph to be simplified: E.g. C depends on B depends on A, squash B, results in C depends on A. This is useful if you only want to know the dependency graph of the submodules of your code and not the separate files of the submodules. The dependencies that should be squashed can be defined using a regex.