### PR TITLE
Fix matching absolute path

### DIFF
--- a/lib/parse/cjs.js
+++ b/lib/parse/cjs.js
@@ -31,7 +31,7 @@ util.inherits(CJS, Base);
  */
 CJS.prototype.normalize = function (filename) {
 	filename = this.replaceBackslashInPath(filename);
-	if (filename.charAt(0) !== '/' && !filename.match(/^[a-z]+\//i)) {
+	if (filename.charAt(0) !== '/' && !filename.match(/^[A-Za-z:]+\//i)) {
 		// a core module (not mapped to a file)
 		return filename;
 	}


### PR DESCRIPTION
The following path is not matched as absolute path during normalization:
"D:/Work/site/src/js/page2/module.js"
"D:/Work/site/node_modules/angular/index.js"
Fix changes it