### PR TITLE
Display a warning when dependency-tree cannot resolve some paths

### DIFF
--- a/lib/tree.js
+++ b/lib/tree.js
@@ -104,6 +104,7 @@ class Tree {
 	generateTree(files) {
 		const depTree = {};
 		const visited = {};
+		const nonExistent = [];
 
 		files.forEach((file) => {
 			if (visited[file]) {
@@ -117,10 +118,16 @@ class Tree {
 				webpackConfig: this.config.webpackConfig,
 				visited: visited,
 				filter: this.filterPath.bind(this),
-				detective: this.config.detectiveOptions
+				detective: this.config.detectiveOptions,
+				nonExistent: nonExistent
 			}));
 		});
-
+		if (nonExistent.length > 0) {
+			console.warn(
+				'WARNING: The following paths could not be resolved. Run with --debug to find out why:\n',
+				nonExistent.join('\n  ')
+			);
+		}
 		let tree = this.convertTree(depTree, {}, {});
 
 		if (this.config.excludeRegExp) {


### PR DESCRIPTION
Sometimes `dependency-tree` cannot resolve all the required paths (due to bugs or configuration problems). Madge should not let these errors go unnoticed since it can result in an incorrect dependency graph.  This pull request adds a warning message to the console.  See https://github.com/dependents/node-dependency-tree/issues/53 for a discussion of this.