### PR TITLE
Update chalk to 2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,13 +59,13 @@
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "chalk": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-      "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
       "requires": {
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
-        "supports-color": "4.4.0"
+        "supports-color": "4.5.0"
       }
     },
     "cli-cursor": {
@@ -2440,9 +2440,9 @@
       }
     },
     "supports-color": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+      "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
       "requires": {
         "has-flag": "2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:output": "./test/output.sh"
   },
   "dependencies": {
-    "chalk": "2.1.0",
+    "chalk": "2.3.0",
     "commander": "2.11.0",
     "commondir": "1.0.1",
     "debug": "^3.1.0",


### PR DESCRIPTION
@pahen Instead of playing whack-a-mole with these dependencies, would you be open for a PR that uses the `^` operator for all dependencies, not just some?