### PR TITLE
chore: upgrade dependency-tree to 6.0.0 to address warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -158,7 +158,7 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.2",
+        "core-js": "2.5.3",
         "regenerator-runtime": "0.11.1"
       }
     },
@@ -292,9 +292,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.2.tgz",
-      "integrity": "sha1-vEZIZW59ydyA19PHu8Fy2W50TmM="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -346,14 +346,14 @@
       }
     },
     "dependency-tree": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-5.12.0.tgz",
-      "integrity": "sha1-obemJUKKbgm8TOXBM/pfa8yWJtM=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-6.0.0.tgz",
+      "integrity": "sha512-/F1jMkrwkdQ69GVOni5a/4YK8OItKr1TeWAk9ctN38K70ciI9JJF5Y92oO6sScEkAwAF4m/lv98kbtf7tFV7Mw==",
       "requires": {
         "commander": "2.12.2",
         "debug": "3.1.0",
-        "filing-cabinet": "1.12.0",
-        "precinct": "3.8.0"
+        "filing-cabinet": "1.13.1",
+        "precinct": "4.0.0"
       }
     },
     "detective-amd": {
@@ -435,13 +435,13 @@
       "integrity": "sha1-UK7n24uruZA4HwEMY/q7pbWOVM0="
     },
     "detective-typescript": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-1.0.1.tgz",
-      "integrity": "sha512-4DZpsap+dVzQblcL/ffVXtaXtA7byrP14XQnvyAvwo8+z7/C0OrwLNQhyiC6cLZlzy2T8QuPc+mDsYsa4lAxHw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-2.0.0.tgz",
+      "integrity": "sha512-0VcvklZWrEAqsGHs1Hp5Px3MfKfHTny7zCVVHQwesrib9XanuV3fsMYQ9iJIfd9bJ196KpBQUPgFHdrp34UB+w==",
       "requires": {
         "node-source-walk": "3.2.0",
-        "typescript": "2.0.10",
-        "typescript-eslint-parser": "1.0.2"
+        "typescript": "2.6.2",
+        "typescript-eslint-parser": "9.0.1"
       },
       "dependencies": {
         "babylon": {
@@ -459,11 +459,6 @@
           "requires": {
             "babylon": "6.8.4"
           }
-        },
-        "typescript": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.0.10.tgz",
-          "integrity": "sha1-zN1O2G/VVQpAcQGggUAS4bP6w90="
         }
       }
     },
@@ -483,9 +478,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.0.3.tgz",
-      "integrity": "sha1-3xTAa1/F7sreEJTJxaErSz7cC2I=",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+      "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
       "requires": {
         "graceful-fs": "4.1.11",
         "memory-fs": "0.4.1",
@@ -494,11 +489,11 @@
       }
     },
     "errno": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
+      "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
       "requires": {
-        "prr": "0.0.0"
+        "prr": "1.0.1"
       }
     },
     "escape-string-regexp": {
@@ -709,33 +704,22 @@
       "integrity": "sha1-5tJptWVnuJIlgTmOmQ3XB49y1hY="
     },
     "filing-cabinet": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.12.0.tgz",
-      "integrity": "sha1-b7k/2WjoO+3xtCmPKCNqiq/ffXg=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-1.13.1.tgz",
+      "integrity": "sha512-uK8bwNArVOuC38LqajIJEs1lpGMtShfGwdM+GuMZVWSaEgO/I9NSh1v8uFTaJL0gTHVT9HJASyTwj8LZONogiA==",
       "requires": {
         "app-module-path": "1.1.0",
         "commander": "2.12.2",
-        "debug": "2.6.9",
-        "enhanced-resolve": "3.0.3",
+        "debug": "3.1.0",
+        "enhanced-resolve": "3.4.1",
         "is-relative-path": "1.0.2",
         "module-definition": "2.2.4",
         "module-lookup-amd": "4.0.5",
-        "object-assign": "4.1.1",
         "resolve": "1.5.0",
         "resolve-dependency-path": "1.0.2",
         "sass-lookup": "1.1.0",
         "stylus-lookup": "1.0.2",
         "typescript": "2.6.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "find": {
@@ -1074,18 +1058,10 @@
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
-    "lodash.tostring": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.4.tgz",
-      "integrity": "sha1-Vgwn0fjq3eA8LM4Zj+9cAx2CmPs="
-    },
     "lodash.unescape": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.0.tgz",
-      "integrity": "sha1-Nt6/xJK4FHhHHvl0zTeD4gLrbO8=",
-      "requires": {
-        "lodash.tostring": "4.1.4"
-      }
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
     },
     "log-symbols": {
       "version": "1.0.2",
@@ -1134,7 +1110,7 @@
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "requires": {
-        "errno": "0.1.4",
+        "errno": "0.1.6",
         "readable-stream": "2.3.3"
       }
     },
@@ -1407,9 +1383,9 @@
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
     },
     "precinct": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/precinct/-/precinct-3.8.0.tgz",
-      "integrity": "sha1-JZqUkKhUd6HyaYn73y+ybETyR1o=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/precinct/-/precinct-4.0.0.tgz",
+      "integrity": "sha512-nMnVxEajGPtM6qBmotQeS7pC4kD+FOvvaDV+N0DwI4hUtAe02KSca4LwL5t+BH7fLfzVd3N270fT+ZMHeFhLCg==",
       "requires": {
         "commander": "2.12.2",
         "debug": "3.1.0",
@@ -1420,7 +1396,7 @@
         "detective-sass": "2.0.1",
         "detective-scss": "1.0.1",
         "detective-stylus": "1.0.0",
-        "detective-typescript": "1.0.1",
+        "detective-typescript": "2.0.0",
         "module-definition": "2.2.4",
         "node-source-walk": "3.3.0"
       }
@@ -1451,9 +1427,9 @@
       "dev": true
     },
     "prr": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -1607,8 +1583,7 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -1878,12 +1853,12 @@
       "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
     },
     "typescript-eslint-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-1.0.2.tgz",
-      "integrity": "sha1-/Sq6zy7j2Tgqs+RJyHYra+rk0Nc=",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-9.0.1.tgz",
+      "integrity": "sha512-w1jqotvnhLtLukD9H3gQPAlbD0kLf7ZkoQGwiwSIshKIlzRL7i0OY9Y7VIdE1xtytZXThg678eomxMZ1rZXGVQ==",
       "requires": {
-        "lodash.unescape": "4.0.0",
-        "object-assign": "4.1.1"
+        "lodash.unescape": "4.0.1",
+        "semver": "5.4.1"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "commander": "^2.11.0",
     "commondir": "^1.0.1",
     "debug": "^3.1.0",
-    "dependency-tree": "^5.11.1",
+    "dependency-tree": "^6.0.0",
     "graphviz": "^0.0.8",
     "mz": "^2.7.0",
     "ora": "^1.3.0",


### PR DESCRIPTION
Upgrade to dependency-tree 6.0.0 to address following warnings: 

```console
npm WARN typescript-eslint-parser@1.0.2 requires a peer of typescript@~2.0.3 but none is installed. You must install peer dependencies yourself.
```
