### PR TITLE
Flow issue when importing a type

### DIFF
--- a/test/flow.js
+++ b/test/flow.js
@@ -20,8 +20,9 @@ describe('Flow', () => {
 	it('extracts CommonsJS module dependencies', (done) => {
 		madge(dir + '/cjs/calc.js').then((res) => {
 			res.obj().should.eql({
+				'geometry.js': [],
 				'math.js': [],
-				'calc.js': ['math.js']
+				'calc.js': ['geometry.js', 'math.js']
 			});
 			done();
 		}).catch(done);

--- a/test/flow/cjs/calc.js
+++ b/test/flow/cjs/calc.js
@@ -1,5 +1,6 @@
 // == calc.js == //
 
+import type { Square } from './geometry.js';
 var Math = require('./math.js');
 
 var four: number = Math.add(2, 2);

--- a/test/flow/cjs/geometry.js
+++ b/test/flow/cjs/geometry.js
@@ -1,0 +1,3 @@
+export type Square = {
+  side: number
+};


### PR DESCRIPTION
I have an issue with madge where it does not find correct dependencies of a module [importing a Flow type](https://flow.org/blog/2015/02/18/Import-Types/).
I've updated the CommomJS + Flow test case to make it fail. It seems to fail one way or another depending on which kind of import comes first.

Do you have an idea of where does the issue come from?