### PR TITLE
Add an .svg public method to the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,20 @@ madge('path/to/app.js')
 	});
 ```
 
+#### .svg()
+
+> Return a `Promise` resolved with the XML SVG representation of the dependency graph as a `Buffer`.
+
+```javascript
+const madge = require('madge');
+
+madge('path/to/app.js')
+	.then((res) => res.svg())
+	.then((output) => {
+		console.log(output.toString());
+	});
+```
+
 # Configuration
 
 Property | Type | Default | Description

--- a/lib/api.js
+++ b/lib/api.js
@@ -150,6 +150,15 @@ class Madge {
 
 		return graph.image(this.obj(), this.circular(), imagePath, this.config);
 	}
+
+	/**
+	 * Return Buffer with XML SVG representation of the dependency graph.
+	 * @api public
+	 * @return {Promise}
+	 */
+	svg() {
+		return graph.svg(this.obj(), this.circular(), this.config);
+	}
 }
 
 /**

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -46,6 +46,7 @@ function createGraphvizOptions(config) {
 	const graphVizOptions = config.graphVizOptions || {};
 
 	return {
+		// Graph
 		G: Object.assign({
 			overlap: false,
 			pad: 0.3,
@@ -53,9 +54,11 @@ function createGraphvizOptions(config) {
 			layout: config.layout,
 			bgcolor: config.backgroundColor
 		}, graphVizOptions.G),
+		// Edge
 		E: Object.assign({
 			color: config.edgeColor
 		}, graphVizOptions.E),
+		// Node
 		N: Object.assign({
 			fontname: config.fontName,
 			fontsize: config.fontSize,
@@ -111,6 +114,24 @@ function createGraph(modules, circular, config, options) {
 		});
 	});
 }
+
+/**
+ * Return the module dependency graph XML SVG representation as a Buffer.
+ * @param  {Object} modules
+ * @param  {Array} circular
+ * @param  {Object} config
+ * @return {Promise}
+ */
+module.exports.svg = function (modules, circular, config) {
+	const options = createGraphvizOptions(config);
+
+	options.type = 'svg';
+
+	return checkGraphvizInstalled(config)
+		.then(() => {
+			return createGraph(modules, circular, config, options);
+		});
+};
 
 /**
  * Creates an image from the module dependency graph.

--- a/test/api.js
+++ b/test/api.js
@@ -216,6 +216,18 @@ describe('API', () => {
 		});
 	});
 
+	describe('svg()', () => {
+		it('returns a promise resolved with XML SVG output in a Buffer', (done) => {
+			madge(__dirname + '/cjs/b.js')
+				.then((res) => res.svg())
+				.then((output) => {
+					output.should.instanceof(Buffer);
+					done();
+				})
+				.catch(done);
+		});
+	});
+
 	describe('image()', () => {
 		let imagePath;
 

--- a/test/api.js
+++ b/test/api.js
@@ -222,6 +222,7 @@ describe('API', () => {
 				.then((res) => res.svg())
 				.then((output) => {
 					output.should.instanceof(Buffer);
+					output.toString().should.match(/<svg.*/);
 					done();
 				})
 				.catch(done);


### PR DESCRIPTION
This method does the exact same as `.image` when used to output an SVG, but it outputs the raw `Buffer` from Graphviz instead of writing it to a file and returning the file path.

For a [project](https://gitlab.com/lleaff/madge-watch-gui/) where I use `madge` to generate many images, bypassing the file system improves performance and simplifies the logic a lot.

Obviously this is just a proposition, the method name could be changed and I could add better tests.