### PR TITLE
Implement invertTree for --summary output

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -34,6 +34,20 @@ module.exports.list = function (modules, opts) {
 	});
 };
 
+function invertTree(tree) {
+	const result = {};
+	Object.keys(tree).forEach((parent) => {
+		result[parent] = [];
+	});
+	Object.keys(tree).forEach((parent) => {
+		const children = tree[parent];
+		children.forEach((child) => {
+			result[child].push(parent);
+		});
+	});
+	return result;
+}
+
 /**
  * Print a summary of module dependencies.
  * @param  {Object} modules
@@ -45,13 +59,19 @@ module.exports.summary = function (modules, opts) {
 
 	opts = opts || {};
 
+	const invertedTree = invertTree(modules);
 	Object.keys(modules).sort((a, b) => {
 		return modules[b].length - modules[a].length;
 	}).forEach((id) => {
 		if (opts.json) {
 			o[id] = modules[id].length;
 		} else {
-			console.log('%s %s', chalk.cyan.bold(modules[id].length), chalk.grey(id));
+			console.log(
+				'%s %s %s',
+				chalk.cyan.bold(modules[id].length),
+				chalk.cyan.bold(invertedTree[id].length),
+				chalk.grey(id)
+			);
 		}
 	});
 


### PR DESCRIPTION
This is just the beginning of an implementation for #162.

![more-summary](https://user-images.githubusercontent.com/18142/44306325-eb8e3500-a340-11e8-8a5c-ed3b5c348cbe.png)

Open questions:
- how to name it?
- where to put it? (in `lib/api.js` or `lib/tree.js`)
- is it important if the output of `--summary` isn't backward compatible?
- in the output, do we want different colors?
- what about tests?

You can takes this and modify it, or give me some answers and I'll add to the PR.

There's also the potential to simplify the `orphans` function in `lib/api.js` by using this. Orphans would be nodes with no incoming connections.