### PR TITLE
Add --no-spinner option

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -28,6 +28,7 @@ program
 	.option('--webpack-config <file>', 'path to webpack config')
 	.option('--include-npm', 'include shallow NPM modules', false)
 	.option('--no-color', 'disable color in output and image', false)
+	.option('--no-spinner', 'disable progress spinner', false)
 	.option('--stdin', 'read predefined tree from STDIN', false)
 	.option('--warning', 'show warnings about skipped files', false)
 	.option('--debug', 'turn on debug output', false)
@@ -105,6 +106,10 @@ if (!program.color) {
 	config.noDependencyColor = '#000000';
 	config.cyclicNodeColor = '#000000';
 	config.edgeColor = '#757575';
+}
+
+if (!program.spinner) {
+	spinner.isEnabled = false;
 }
 
 function dependencyFilter() {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -63,7 +63,8 @@ program.options.forEach((opt) => {
 const spinner = ora({
 	text: 'Finding files',
 	color: 'white',
-	interval: 100000
+	interval: 100000,
+	isEnabled: program.spinner
 });
 
 let exitCode = 0;
@@ -108,10 +109,6 @@ if (!program.color) {
 	config.edgeColor = '#757575';
 }
 
-if (!program.spinner) {
-	spinner.isEnabled = false;
-}
-
 function dependencyFilter() {
 	let prevFile;
 
@@ -121,8 +118,10 @@ function dependencyFilter() {
 			const dir = path.dirname(relPath) + '/';
 			const file = path.basename(relPath);
 
-			spinner.text = chalk.grey(dir) + chalk.cyan(file);
-			spinner.render();
+			if (program.spinner) {
+				spinner.text = chalk.grey(dir) + chalk.cyan(file);
+				spinner.render();
+			}
 			prevFile = traversedFilePath;
 		}
 	};

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "debug": "^3.1.0",
     "dependency-tree": "^6.1.0",
     "graphviz": "^0.0.8",
-    "ora": "^2.1.0",
+    "ora": "^3.0.0",
     "pify": "^3.0.0",
     "pluralize": "^7.0.0",
     "pretty-ms": "^3.1.0",


### PR DESCRIPTION
Fixes #156

Adds a `--no-spinner` option which disables the spinner animation and prevents the spinner from rendering in the dependency filter.

Please squash the commits when merging.