### PR TITLE
If graphical output required, check for gvpr available before building a tree

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -49,7 +49,7 @@ if (!program.color) {
 
 const log = require('../lib/log');
 const output = require('../lib/output');
-const madge = require('../lib/api');
+const Madge = require('../lib/api')();
 const config = Object.assign({}, rc);
 
 program.options.forEach((opt) => {
@@ -149,12 +149,18 @@ new Promise((resolve, reject) => {
 	}
 })
 	.then((src) => {
+		if (program.dot || program.image) {
+			return Madge.checkGraphviz(config.graphVizPath).then(() => {
+				return new Madge(src, config);
+			});
+		}
+
 		if (!program.json && !program.dot) {
 			spinner.start();
 			config.dependencyFilter = dependencyFilter();
 		}
 
-		return madge(src, config);
+		return new Madge(src, config);
 	})
 	.then((res) => {
 		if (!program.json && !program.dot) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -63,6 +63,10 @@ class Madge {
 		});
 	}
 
+	static checkGraphviz(graphVizPath) {
+		return graph.checkGraphvizInstalled(graphVizPath);
+	}
+
 	/**
 	 * Return the module dependency graph as an object.
 	 * @api public
@@ -154,8 +158,6 @@ class Madge {
 
 /**
  * Expose API.
- * @param {String|Array} path
- * @param {Object} config
- * @return {Promise}
+ * @return {Madge}
  */
-module.exports = (path, config) => new Madge(path, config);
+module.exports = () => Madge;

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -18,26 +18,6 @@ function setNodeColor(node, color) {
 }
 
 /**
- * Check if Graphviz is installed on the system.
- * @param  {Object} config
- * @return {Promise}
- */
-function checkGraphvizInstalled(config) {
-	if (config.graphVizPath) {
-		const cmd = path.join(config.graphVizPath, 'gvpr -V');
-		return exec(cmd)
-			.catch(() => {
-				throw new Error('Could not execute ' + cmd);
-			});
-	}
-
-	return exec('gvpr -V')
-		.catch((error) => {
-			throw new Error('Graphviz could not be found. Ensure that "gvpr" is in your $PATH.\n' + error);
-		});
-}
-
-/**
  * Return options to use with graphviz digraph.
  * @param  {Object} config
  * @return {Object}
@@ -112,6 +92,27 @@ function createGraph(modules, circular, config, options) {
 	});
 }
 
+
+/**
+ * Check if Graphviz is installed on the system.
+ * @param  {String} graphVizPath
+ * @return {Promise}
+ */
+module.exports.checkGraphvizInstalled = function (graphVizPath) {
+	if (graphVizPath) {
+		const cmd = path.join(graphVizPath, 'gvpr -V');
+		return exec(cmd)
+			.catch(() => {
+				throw new Error('Could not execute ' + cmd);
+			});
+	}
+
+	return exec('gvpr -V')
+		.catch((error) => {
+			throw new Error('Graphviz could not be found. Ensure that "gvpr" is in your $PATH.\n' + error);
+		});
+};
+
 /**
  * Creates an image from the module dependency graph.
  * @param  {Object} modules
@@ -125,35 +126,29 @@ module.exports.image = function (modules, circular, imagePath, config) {
 
 	options.type = path.extname(imagePath).replace('.', '') || 'png';
 
-	return checkGraphvizInstalled(config)
-		.then(() => {
-			return createGraph(modules, circular, config, options)
+	return createGraph(modules, circular, config, options)
 				.then((image) => writeFile(imagePath, image))
 				.then(() => path.resolve(imagePath));
-		});
 };
 
 /**
  * Return the module dependency graph as DOT output.
  * @param  {Object} modules
- * @param  {Object} config
  * @return {Promise}
  */
-module.exports.dot = function (modules, config) {
+module.exports.dot = function (modules) {
 	const nodes = {};
 	const g = graphviz.digraph('G');
 
-	return checkGraphvizInstalled(config)
-		.then(() => {
-			Object.keys(modules).forEach((id) => {
-				nodes[id] = nodes[id] || g.addNode(id);
+	
+		Object.keys(modules).forEach((id) => {
+			nodes[id] = nodes[id] || g.addNode(id);
 
-				modules[id].forEach((depId) => {
-					nodes[depId] = nodes[depId] || g.addNode(depId);
-					g.addEdge(nodes[id], nodes[depId]);
-				});
+			modules[id].forEach((depId) => {
+				nodes[depId] = nodes[depId] || g.addNode(depId);
+				g.addEdge(nodes[id], nodes[depId]);
 			});
-
-			return g.to_dot();
 		});
+
+		return g.to_dot();
 };

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -127,8 +127,8 @@ module.exports.image = function (modules, circular, imagePath, config) {
 	options.type = path.extname(imagePath).replace('.', '') || 'png';
 
 	return createGraph(modules, circular, config, options)
-				.then((image) => writeFile(imagePath, image))
-				.then(() => path.resolve(imagePath));
+		.then((image) => writeFile(imagePath, image))
+		.then(() => path.resolve(imagePath));
 };
 
 /**
@@ -140,15 +140,14 @@ module.exports.dot = function (modules) {
 	const nodes = {};
 	const g = graphviz.digraph('G');
 
-	
-		Object.keys(modules).forEach((id) => {
-			nodes[id] = nodes[id] || g.addNode(id);
+	Object.keys(modules).forEach((id) => {
+		nodes[id] = nodes[id] || g.addNode(id);
 
-			modules[id].forEach((depId) => {
-				nodes[depId] = nodes[depId] || g.addNode(depId);
-				g.addEdge(nodes[id], nodes[depId]);
-			});
+		modules[id].forEach((depId) => {
+			nodes[depId] = nodes[depId] || g.addNode(depId);
+			g.addEdge(nodes[id], nodes[depId]);
 		});
+	});
 
-		return g.to_dot();
+	return g.to_dot();
 };

--- a/test/amd.js
+++ b/test/amd.js
@@ -1,14 +1,14 @@
 /* eslint-env mocha */
 'use strict';
 
-const madge = require('../lib/api');
+const Madge = require('../lib/api')();
 require('should');
 
 describe('AMD', () => {
 	const dir = __dirname + '/amd';
 
 	it('finds recursive dependencies', (done) => {
-		madge(dir + '/ok/a.js').then((res) => {
+		new Madge(dir + '/ok/a.js').then((res) => {
 			res.obj().should.eql({
 				'a.js': ['sub/b.js'],
 				'sub/b.js': ['sub/c.js'],
@@ -20,7 +20,7 @@ describe('AMD', () => {
 	});
 
 	it('ignores plugins', (done) => {
-		madge(dir + '/plugin.js').then((res) => {
+		new Madge(dir + '/plugin.js').then((res) => {
 			res.obj().should.eql({
 				'plugin.js': ['ok/d.js'],
 				'ok/d.js': []
@@ -30,7 +30,7 @@ describe('AMD', () => {
 	});
 
 	it('finds nested dependencies', (done) => {
-		madge(dir + '/nested/main.js').then((res) => {
+		new Madge(dir + '/nested/main.js').then((res) => {
 			res.obj().should.eql({
 				'a.js': [],
 				'b.js': [],
@@ -44,7 +44,7 @@ describe('AMD', () => {
 	});
 
 	it('finds circular dependencies', (done) => {
-		madge(dir + '/circular/main.js').then((res) => {
+		new Madge(dir + '/circular/main.js').then((res) => {
 			res.circular().should.eql([
 				['a.js', 'c.js'],
 				['f.js', 'g.js', 'h.js']
@@ -54,14 +54,14 @@ describe('AMD', () => {
 	});
 
 	it('finds circular dependencies with relative paths', (done) => {
-		madge(dir + '/circularRelative/a.js').then((res) => {
+		new Madge(dir + '/circularRelative/a.js').then((res) => {
 			res.circular().should.eql([['a.js', 'foo/b.js']]);
 			done();
 		}).catch(done);
 	});
 
 	it('finds circular dependencies with alias', (done) => {
-		madge(dir + '/circularAlias/dos.js', {
+		new Madge(dir + '/circularAlias/dos.js', {
 			requireConfig: dir + '/circularAlias/config.js'
 		}).then((res) => {
 			res.circular().should.eql([['dos.js', 'x86.js']]);
@@ -70,7 +70,7 @@ describe('AMD', () => {
 	});
 
 	it('works for files with ES6 code inside', (done) => {
-		madge(dir + '/amdes6.js').then((res) => {
+		new Madge(dir + '/amdes6.js').then((res) => {
 			res.obj().should.eql({
 				'amdes6.js': ['ok/d.js'],
 				'ok/d.js': []
@@ -80,7 +80,7 @@ describe('AMD', () => {
 	});
 
 	it('uses paths found in RequireJS config', (done) => {
-		madge(dir + '/requirejs/a.js', {
+		new Madge(dir + '/requirejs/a.js', {
 			requireConfig: dir + '/requirejs/config.js'
 		}).then((res) => {
 			res.obj().should.eql({

--- a/test/api.js
+++ b/test/api.js
@@ -4,30 +4,30 @@
 const os = require('os');
 const path = require('path');
 const fs = require('mz/fs');
-const madge = require('../lib/api');
+const Madge = require('../lib/api')();
 
 require('should');
 
 describe('API', () => {
 	it('throws error on missing path argument', () => {
 		(() => {
-			madge();
+			return new Madge();
 		}).should.throw('path argument not provided');
 	});
 
 	it('returns a Promise', () => {
-		madge(__dirname + '/cjs/a.js').should.be.Promise(); // eslint-disable-line new-cap
+		new Madge(__dirname + '/cjs/a.js').should.be.Promise(); // eslint-disable-line new-cap
 	});
 
 	it('throws error if file or directory does not exists', (done) => {
-		madge(__dirname + '/missing.js').catch((err) => {
+		new Madge(__dirname + '/missing.js').catch((err) => {
 			err.message.should.match(/no such file or directory/);
 			done();
 		}).catch(done);
 	});
 
 	it('takes single file as path', (done) => {
-		madge(__dirname + '/cjs/a.js').then((res) => {
+		new Madge(__dirname + '/cjs/a.js').then((res) => {
 			res.obj().should.eql({
 				'a.js': ['b.js', 'c.js'],
 				'b.js': ['c.js'],
@@ -38,7 +38,7 @@ describe('API', () => {
 	});
 
 	it('takes an array of files as path and combines the result', (done) => {
-		madge([__dirname + '/cjs/a.js', __dirname + '/cjs/normal/d.js']).then((res) => {
+		new Madge([__dirname + '/cjs/a.js', __dirname + '/cjs/normal/d.js']).then((res) => {
 			res.obj().should.eql({
 				'a.js': ['b.js', 'c.js'],
 				'b.js': ['c.js'],
@@ -50,7 +50,7 @@ describe('API', () => {
 	});
 
 	it('take a single directory as path and find files in it', (done) => {
-		madge(__dirname + '/cjs/normal').then((res) => {
+		new Madge(__dirname + '/cjs/normal').then((res) => {
 			res.obj().should.eql({
 				'a.js': ['sub/b.js'],
 				'd.js': [],
@@ -62,7 +62,7 @@ describe('API', () => {
 	});
 
 	it('takes an array of directories as path and compute the basedir correctly', (done) => {
-		madge([__dirname + '/cjs/multibase/1', __dirname + '/cjs/multibase/2']).then((res) => {
+		new Madge([__dirname + '/cjs/multibase/1', __dirname + '/cjs/multibase/2']).then((res) => {
 			res.obj().should.eql({
 				'1/a.js': [],
 				'2/b.js': []
@@ -72,7 +72,7 @@ describe('API', () => {
 	});
 
 	it('takes a predefined tree', (done) => {
-		madge({
+		new Madge({
 			a: ['b', 'c', 'd'],
 			b: ['c'],
 			c: [],
@@ -89,7 +89,7 @@ describe('API', () => {
 	});
 
 	it('can exclude modules using RegExp', (done) => {
-		madge(__dirname + '/cjs/a.js', {
+		new Madge(__dirname + '/cjs/a.js', {
 			excludeRegExp: ['^b.js$']
 		}).then((res) => {
 			res.obj().should.eql({
@@ -102,7 +102,7 @@ describe('API', () => {
 
 	describe('dependencyFilter', () => {
 		it('will stop traversing when returning false', (done) => {
-			madge(__dirname + '/cjs/a.js', {
+			new Madge(__dirname + '/cjs/a.js', {
 				dependencyFilter: () => {
 					return false;
 				}
@@ -115,7 +115,7 @@ describe('API', () => {
 		});
 
 		it('will not stop traversing when not returning anything', (done) => {
-			madge(__dirname + '/cjs/a.js', {
+			new Madge(__dirname + '/cjs/a.js', {
 				dependencyFilter: () => {}
 			}).then((res) => {
 				res.obj().should.eql({
@@ -130,7 +130,7 @@ describe('API', () => {
 		it('will pass arguments to the function', (done) => {
 			let counter = 0;
 
-			madge(__dirname + '/cjs/a.js', {
+			new Madge(__dirname + '/cjs/a.js', {
 				dependencyFilter: (dependencyFilePath, traversedFilePath, baseDir) => {
 					if (counter === 0) {
 						dependencyFilePath.should.match(/test\/cjs\/b\.js$/);
@@ -160,7 +160,7 @@ describe('API', () => {
 
 	describe('obj()', () => {
 		it('returns dependency object', (done) => {
-			madge(__dirname + '/cjs/a.js').then((res) => {
+			new Madge(__dirname + '/cjs/a.js').then((res) => {
 				res.obj().should.eql({
 					'a.js': ['b.js', 'c.js'],
 					'b.js': ['c.js'],
@@ -173,7 +173,7 @@ describe('API', () => {
 
 	describe('warnings()', () => {
 		it('returns an array of skipped files', (done) => {
-			madge(__dirname + '/cjs/missing.js').then((res) => {
+			new Madge(__dirname + '/cjs/missing.js').then((res) => {
 				res.obj().should.eql({
 					'missing.js': ['c.js'],
 					'c.js': []
@@ -188,7 +188,7 @@ describe('API', () => {
 
 	describe('dot()', () => {
 		it('returns a promise resolved with graphviz DOT output', (done) => {
-			madge(__dirname + '/cjs/b.js')
+			new Madge(__dirname + '/cjs/b.js')
 				.then((res) => res.dot())
 				.then((output) => {
 					output.should.eql('digraph G {\n  "b.js";\n  "c.js";\n  "b.js" -> "c.js";\n}\n');
@@ -200,7 +200,7 @@ describe('API', () => {
 
 	describe('depends()', () => {
 		it('returns modules that depends on another', (done) => {
-			madge(__dirname + '/cjs/a.js').then((res) => {
+			new Madge(__dirname + '/cjs/a.js').then((res) => {
 				res.depends('c.js').should.eql(['a.js', 'b.js']);
 				done();
 			}).catch(done);
@@ -209,7 +209,7 @@ describe('API', () => {
 
 	describe('orphans()', () => {
 		it('returns modules that no one is depending on', (done) => {
-			madge(__dirname + '/cjs/normal').then((res) => {
+			new Madge(__dirname + '/cjs/normal').then((res) => {
 				res.orphans().should.eql(['a.js']);
 				done();
 			}).catch(done);
@@ -228,7 +228,7 @@ describe('API', () => {
 		});
 
 		it('rejects if a filename is not supplied', (done) => {
-			madge(__dirname + '/cjs/a.js')
+			new Madge(__dirname + '/cjs/a.js')
 				.then((res) => res.image())
 				.catch((err) => {
 					err.message.should.eql('imagePath not provided');
@@ -237,7 +237,7 @@ describe('API', () => {
 		});
 
 		it('rejects on unsupported image format', (done) => {
-			madge(__dirname + '/cjs/a.js')
+			new Madge(__dirname + '/cjs/a.js')
 				.then((res) => res.image('image.zyx'))
 				.catch((err) => {
 					err.message.should.match(/Format: "zyx" not recognized/);
@@ -246,8 +246,8 @@ describe('API', () => {
 		});
 
 		it('rejects if graphviz is not installed', (done) => {
-			madge(__dirname + '/cjs/a.js', {graphVizPath: '/invalid/path'})
-				.then((res) => res.image('image.png'))
+			const invalidGraphVizPath = '/invalid/path';
+			Madge.checkGraphviz(invalidGraphVizPath)
 				.catch((err) => {
 					err.message.should.match(/Could not execute .*gvpr \-V/);
 					done();
@@ -255,7 +255,7 @@ describe('API', () => {
 		});
 
 		it('writes image to file', (done) => {
-			madge(__dirname + '/cjs/a.js')
+			new Madge(__dirname + '/cjs/a.js')
 				.then((res) => res.image(imagePath))
 				.then((writtenImagePath) => {
 					writtenImagePath.should.eql(imagePath);

--- a/test/cjs.js
+++ b/test/cjs.js
@@ -1,14 +1,14 @@
 /* eslint-env mocha */
 'use strict';
 
-const madge = require('../lib/api');
+const Madge = require('../lib/api')();
 require('should');
 
 describe('CommonJS', () => {
 	const dir = __dirname + '/cjs';
 
 	it('finds recursive dependencies', (done) => {
-		madge(dir + '/normal/a.js').then((res) => {
+		new Madge(dir + '/normal/a.js').then((res) => {
 			res.obj().should.eql({
 				'a.js': ['sub/b.js'],
 				'd.js': [],
@@ -20,7 +20,7 @@ describe('CommonJS', () => {
 	});
 
 	it('handles path outside directory', (done) => {
-		madge(dir + '/normal/sub/c.js').then((res) => {
+		new Madge(dir + '/normal/sub/c.js').then((res) => {
 			res.obj().should.eql({
 				'../d.js': [],
 				'c.js': ['../d.js']
@@ -30,7 +30,7 @@ describe('CommonJS', () => {
 	});
 
 	it('finds circular dependencies', (done) => {
-		madge(dir + '/circular/a.js').then((res) => {
+		new Madge(dir + '/circular/a.js').then((res) => {
 			res.circular().should.eql([
 				['a.js', 'd.js']
 			]);
@@ -39,14 +39,14 @@ describe('CommonJS', () => {
 	});
 
 	it('handle extensions when finding circular dependencies', (done) => {
-		madge(dir + '/circular/foo.js').then((res) => {
+		new Madge(dir + '/circular/foo.js').then((res) => {
 			res.circular().should.eql([]);
 			done();
 		}).catch(done);
 	});
 
 	it('excludes core modules by default', (done) => {
-		madge(dir + '/core.js').then((res) => {
+		new Madge(dir + '/core.js').then((res) => {
 			res.obj().should.eql({
 				'core.js': []
 			});
@@ -55,7 +55,7 @@ describe('CommonJS', () => {
 	});
 
 	it('excludes NPM modules by default', (done) => {
-		madge(dir + '/npm.js').then((res) => {
+		new Madge(dir + '/npm.js').then((res) => {
 			res.obj().should.eql({
 				'normal/d.js': [],
 				'npm.js': ['normal/d.js']
@@ -65,7 +65,7 @@ describe('CommonJS', () => {
 	});
 
 	it('can include shallow NPM modules', (done) => {
-		madge(dir + '/npm.js', {
+		new Madge(dir + '/npm.js', {
 			includeNpm: true
 		}).then((res) => {
 			res.obj().should.eql({

--- a/test/es6.js
+++ b/test/es6.js
@@ -1,14 +1,14 @@
 /* eslint-env mocha */
 'use strict';
 
-const madge = require('../lib/api');
+const Madge = require('../lib/api')();
 require('should');
 
 describe('ES6', () => {
 	const dir = __dirname + '/es6';
 
 	it('extracts dependencies', (done) => {
-		madge(dir + '/absolute.js').then((res) => {
+		new Madge(dir + '/absolute.js').then((res) => {
 			res.obj().should.eql({
 				'absolute.js': ['absolute/a.js'],
 				'absolute/a.js': []
@@ -18,7 +18,7 @@ describe('ES6', () => {
 	});
 
 	it('finds circular dependencies', (done) => {
-		madge(dir + '/circular/a.js').then((res) => {
+		new Madge(dir + '/circular/a.js').then((res) => {
 			res.circular().should.eql([
 				['a.js', 'b.js', 'c.js']
 			]);
@@ -27,7 +27,7 @@ describe('ES6', () => {
 	});
 
 	it('tackles error in files', (done) => {
-		madge(dir + '/error.js').then((res) => {
+		new Madge(dir + '/error.js').then((res) => {
 			res.obj().should.eql({
 				'error.js': []
 			});
@@ -36,7 +36,7 @@ describe('ES6', () => {
 	});
 
 	it('supports export x from "./file"', (done) => {
-		madge(dir + '/re-export/c.js').then((res) => {
+		new Madge(dir + '/re-export/c.js').then((res) => {
 			res.obj().should.eql({
 				'a.js': [],
 				'b-default.js': ['a.js'],
@@ -53,7 +53,7 @@ describe('ES6', () => {
 	});
 
 	it('supports resolve root paths in webpack config', (done) => {
-		madge(dir + '/webpack/src/sub/index.js', {
+		new Madge(dir + '/webpack/src/sub/index.js', {
 			webpackConfig: dir + '/webpack/webpack.config.js'
 		}).then((res) => {
 			res.obj().should.eql({

--- a/test/es7.js
+++ b/test/es7.js
@@ -1,14 +1,14 @@
 /* eslint-env mocha */
 'use strict';
 
-const madge = require('../lib/api');
+const Madge = require('../lib/api')();
 require('should');
 
 describe('ES7', () => {
 	const dir = __dirname + '/es7';
 
 	it('extracts dependencies', (done) => {
-		madge(dir + '/async.js').then((res) => {
+		new Madge(dir + '/async.js').then((res) => {
 			res.obj().should.eql({
 				'other.js': [],
 				'async.js': ['other.js']

--- a/test/flow.js
+++ b/test/flow.js
@@ -1,14 +1,14 @@
 /* eslint-env mocha */
 'use strict';
 
-const madge = require('../lib/api');
+const Madge = require('../lib/api')();
 require('should');
 
 describe('Flow', () => {
 	const dir = __dirname + '/flow';
 
 	it('extracts ES module ependencies', (done) => {
-		madge(dir + '/es/calc.js').then((res) => {
+		new Madge(dir + '/es/calc.js').then((res) => {
 			res.obj().should.eql({
 				'math.js': [],
 				'calc.js': ['math.js']
@@ -18,7 +18,7 @@ describe('Flow', () => {
 	});
 
 	it('extracts CommonsJS module dependencies', (done) => {
-		madge(dir + '/cjs/calc.js').then((res) => {
+		new Madge(dir + '/cjs/calc.js').then((res) => {
 			res.obj().should.eql({
 				'math.js': [],
 				'calc.js': ['math.js']

--- a/test/jsx.js
+++ b/test/jsx.js
@@ -1,14 +1,14 @@
 /* eslint-env mocha */
 'use strict';
 
-const madge = require('../lib/api');
+const Madge = require('../lib/api')();
 require('should');
 
 describe('JSX', () => {
 	const dir = __dirname + '/jsx';
 
 	it('finds import in JSX files', (done) => {
-		madge(dir + '/basic.jsx').then((res) => {
+		new Madge(dir + '/basic.jsx').then((res) => {
 			res.obj().should.eql({
 				'basic.jsx': ['other.jsx'],
 				'other.jsx': []

--- a/test/typescript.js
+++ b/test/typescript.js
@@ -1,14 +1,14 @@
 /* eslint-env mocha */
 'use strict';
 
-const madge = require('../lib/api');
+const Madge = require('../lib/api')();
 require('should');
 
 describe('TypeScript', () => {
 	const dir = __dirname + '/typescript';
 
 	it('extracts module dependencies', (done) => {
-		madge(dir + '/import.ts').then((res) => {
+		new Madge(dir + '/import.ts').then((res) => {
 			res.obj().should.eql({
 				'import.ts': ['require.ts'],
 				'require.ts': ['export.ts'],


### PR DESCRIPTION
**Motivation** is that calculations are first performed and the you figure out that you can't have a visual bc lib in not properly installed. That happened in my case too.
So I added a check for gvpr in front of the tree building in case if image is requested.
Maybe that's too much of a change in signatures. But I wanted to keep the dependance chain graph.js -> api.js -> cli.js same as it was.

**Current approach:** move checkGraphvizInstalled to static method of Madge class, then it can be run before creating a tree

**Alternative:** move checkGraphvizInstalled to a separate file (utils.js?) and include it directly in cli.js