### PR TITLE
Add support for `--include` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Property | Type | Default | Description
 `baseDir` | String | null | Base directory to use instead of the default
 `includeNpm` | Boolean | false | If shallow NPM modules should be included
 `fileExtensions` | Array | ['js'] | Valid file extensions used to find files in directories
+`includeRegExp` | Array | false | An array of RegExp for including modules (only matching modules will be included)
 `excludeRegExp` | Array | false | An array of RegExp for excluding modules
 `requireConfig` | String | null | RequireJS config for resolving aliased modules
 `webpackConfig` | String | null | Webpack config for resolving aliased modules

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,6 +10,8 @@ const ora = require('ora');
 const chalk = require('chalk');
 const startTime = Date.now();
 
+const collect = (value, prev) => prev.concat([value]);
+
 program
 	.version(version)
 	.usage('[options] <src...>')
@@ -17,7 +19,8 @@ program
 	.option('-s, --summary', 'show dependency count summary')
 	.option('-c, --circular', 'show circular dependencies')
 	.option('-d, --depends <name>', 'show module dependents')
-	.option('-x, --exclude <regexp>', 'exclude modules using RegExp')
+	.option('-x, --exclude <regexp>', 'exclude modules using RegExp (can be used multiple times)', collect, [])
+	.option('--include <regexp>', 'include modules using RegExp (can be used multiple times)', collect, [])
 	.option('-j, --json', 'output as JSON')
 	.option('-i, --image <file>', 'write graph to file as an image')
 	.option('-l, --layout <name>', 'layout engine to use for graph (dot/neato/fdp/sfdp/twopi/circo)')
@@ -82,8 +85,12 @@ if (program.basedir) {
 	config.baseDir = program.basedir;
 }
 
-if (program.exclude) {
-	config.excludeRegExp = [program.exclude];
+if (program.exclude.length) {
+	config.excludeRegExp = program.exclude;
+}
+
+if (program.include.length) {
+	config.includeRegExp = program.include;
 }
 
 if (program.extensions) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -8,6 +8,7 @@ const log = require('./log');
 const defaultConfig = {
 	baseDir: null,
 	excludeRegExp: false,
+	includeRegExp: false,
 	fileExtensions: ['js'],
 	includeNpm: false,
 	requireConfig: null,

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -149,8 +149,8 @@ class Tree {
 			});
 		}
 
-		if (this.config.excludeRegExp) {
-			tree = this.exclude(tree, this.config.excludeRegExp);
+		if (this.config.excludeRegExp || this.config.includeRegExp) {
+			tree = this.exclude(tree, this.config.includeRegExp, this.config.excludeRegExp);
 		}
 
 		return {
@@ -218,15 +218,18 @@ class Tree {
 
 	/**
 	 * Exclude modules from tree using RegExp.
-	 * @param  {Object} tree
-	 * @param  {Array} excludeRegExp
+	 * @param {Object} tree
+	 * @param {(Array|false)} includeRegExp
+	 * @param {(Array|false)} excludeRegExp
 	 * @return {Object}
 	 */
-	exclude(tree, excludeRegExp) {
-		const regExpList = excludeRegExp.map((re) => new RegExp(re));
+	exclude(tree, includeRegExp, excludeRegExp) {
+		const includeList = includeRegExp ? includeRegExp.map((re) => new RegExp(re)) : false;
+		const excludeList = excludeRegExp ? excludeRegExp.map((re) => new RegExp(re)) : false;
 
 		function regExpFilter(id) {
-			return regExpList.findIndex((regexp) => regexp.test(id)) < 0;
+			return (!includeList || includeList.findIndex((re) => re.test(id)) >= 0) &&
+			(!excludeList || excludeList.findIndex((re) => re.test(id)) < 0);
 		}
 
 		return Object


### PR DESCRIPTION
This PR adds support for an `--include` flag, as per #219, that filters out everything in the tree that's not matched by the regular expressions provided.

Also made the `--include` / `--exclude` flags accumulate their values in arrays, so you can provide the flags more than once in a command.

You can run `madge` off my branch with:

```bash
npx danburzo/madge#include ...
```