### PR TITLE
feat: add support for graph that includes only circular deps

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -202,12 +202,23 @@ new Promise((resolve, reject) => {
 				exitCode = 1;
 			}
 
+			if (program.image) {
+				return res.circularImage(program.image).then((imagePath) => {
+					spinner.succeed(
+						`${chalk.bold('Image created at')} ${chalk.cyan.bold(imagePath)}`
+					);
+					return res;
+				});
+			}
+
 			return res;
 		}
 
 		if (program.image) {
 			return res.image(program.image).then((imagePath) => {
-				spinner.succeed(`${chalk.bold('Image created at')} ${chalk.cyan.bold(imagePath)}`);
+				spinner.succeed(
+					`${chalk.bold('Image created at')} ${chalk.cyan.bold(imagePath)}`
+				);
 				return res;
 			});
 		}

--- a/lib/api.js
+++ b/lib/api.js
@@ -152,6 +152,23 @@ class Madge {
 		return graph.image(this.obj(), this.circular(), imagePath, this.config);
 	}
 
+	circularImage(imagePath) {
+		if (!imagePath) {
+			return Promise.reject(new Error('imagePath not provided'));
+		}
+
+		const circular = this.circular();
+
+		const newTree = Object.entries(this.obj())
+			.filter(([k, v]) => circular.some((x) => x.includes(k)))
+			.reduce((acc, [k, v]) => {
+				acc[k] = v.filter((x) => circular.some((y) => y.includes(x)));
+				return acc;
+			}, {});
+
+		return graph.image(newTree, circular, imagePath, this.config);
+	}
+
 	/**
 	 * Return Buffer with XML SVG representation of the dependency graph.
 	 * @api public


### PR DESCRIPTION
This is my take on #223 , tested it against a medium size app and it worked fine.

Let me know if there's anything you would like me to change