### PR TITLE
feat: support package.json config

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,9 @@ Property | Type | Default | Description
 `detectiveOptions` | Object | false | Custom `detective` options for [dependency-tree](https://github.com/dependents/node-dependency-tree) and [precinct](https://github.com/dependents/node-precinct#usage)
 `dependencyFilter` | Function | false | Function called with a dependency filepath (exclude substree by returning false)
 
-> Note that when running the CLI it's possible to use a runtime configuration file. The config should placed in `.madgerc` in your project or home folder. Look [here](https://github.com/dominictarr/rc#standards) for alternative locations for the file. Here's an example:
+You can use configuration file either in `.madgerc` in your project or home folder or directly in `package.json`. Look [here](https://github.com/dominictarr/rc#standards) for alternative locations for the file.
+
+> .madgerc
 
 ```json
 {
@@ -228,6 +230,23 @@ Property | Type | Default | Description
 	"graphVizOptions": {
 		"G": {
 			"rankdir": "LR"
+		}
+	}
+}
+```
+
+> package.json
+```json
+{
+	"name": "foo",
+	"version": "0.0.1",
+	...
+	"madge": {
+		"fontSize": "10px",
+		"graphVizOptions": {
+			"G": {
+				"rankdir": "LR"
+			}
 		}
 	}
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -51,7 +51,12 @@ if (!program.color) {
 const log = require('../lib/log');
 const output = require('../lib/output');
 const madge = require('../lib/api');
-const config = Object.assign(rc, getPackageConfig());
+
+let packageConfig = {};
+try {
+	packageConfig = require(path.join(process.cwd(), 'package.json')).madge;
+} catch (e) { }
+const config = Object.assign(rc, packageConfig);
 
 program.options.forEach((opt) => {
 	const name = opt.name();
@@ -130,14 +135,6 @@ function dependencyFilter() {
 			prevFile = traversedFilePath;
 		}
 	};
-}
-
-function getPackageConfig() {
-	try {
-		return require(path.join(process.cwd(), 'package.json')).madge;
-	} catch (err) {
-		return {};
-	}
 }
 
 new Promise((resolve, reject) => {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -51,7 +51,7 @@ if (!program.color) {
 const log = require('../lib/log');
 const output = require('../lib/output');
 const madge = require('../lib/api');
-const config = Object.assign({}, rc);
+const config = Object.assign(rc, getPackageConfig());
 
 program.options.forEach((opt) => {
 	const name = opt.name();
@@ -130,6 +130,14 @@ function dependencyFilter() {
 			prevFile = traversedFilePath;
 		}
 	};
+}
+
+function getPackageConfig() {
+	try {
+		return require(path.join(process.cwd(), 'package.json')).madge;
+	} catch (err) {
+		return {};
+	}
 }
 
 new Promise((resolve, reject) => {


### PR DESCRIPTION
fix #235 

So this line is a bit ugly:
```js
return require(path.join(process.cwd(), 'package.json')).madge;
```
But due to eslint i'm forced to do it because of the `nosync` rule. Making the `fs` lookup for the `package.json` async would wrap everything up into a promise; which involves more coding for not so much benefit.

Let me know your thoughts about it.