### PR TITLE
chore: significant speedup by skipping filing-cabinet ts-config parsing

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -107,6 +107,13 @@ if (program.tsConfig) {
 	config.tsConfig = program.tsConfig;
 }
 
+if (config.tsConfig) {
+	const ts = require('typescript');
+	const tsParsedConfig = ts.readJsonConfigFile(config.tsConfig, ts.sys.readFile);
+	const obj = ts.parseJsonSourceFileConfigFileContent(tsParsedConfig, ts.sys, path.dirname(config.tsConfig));
+	config.tsConfig = obj.raw;
+}
+
 if (program.includeNpm) {
 	config.includeNpm = program.includeNpm;
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "pluralize": "^8.0.0",
     "pretty-ms": "^5.0.0",
     "rc": "^1.2.7",
+    "typescript": "^3.7.5",
     "walkdir": "^0.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
`madge` is annoyingly slow for us. This patch takes it from `1m26s` to `7s` (>10x speedup), for ~2,000 typescript files.

`filing-cabinet`, which the dependency walking stuff runs internally, runs this incredibly slow config loader in the loop. Instead, do it at the top, and pass the object in, which it already supports.

Config loading mostly copied from: https://github.com/dependents/node-filing-cabinet/blob/74185e06edbbcbb3062265946adbada9b5584999/index.js#L199-L201

This is essentially just doing `JSON.parse(fs.loadFileSync(..))`, aiui. except it copes with some typescript weirdness (e.g. comments in the json).

I'm not sure that's really the best place to translate the config object, but the `program.tsConfig` above seems not to be hit? I don't really understand why.