### PR TITLE
Added `leaves` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,18 @@ madge('path/to/app.js').then((res) => {
 });
 ```
 
+#### .leaves()
+
+> Return an `Array` of all modules that have no dependencies.
+
+```javascript
+const madge = require('madge');
+
+madge('path/to/app.js').then((res) => {
+	console.log(res.leaves());
+});
+```
+
 #### .dot()
 
 > Returns a `Promise` resolved with a DOT representation of the module dependency graph.
@@ -302,6 +314,10 @@ $ madge --depends wheels.js path/src/app.js
 
 ```sh
 $ madge --orphans path/src/
+```
+
+```sh
+$ madge --leaves path/src/
 ```
 
 > Excluding modules

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -173,65 +173,9 @@ new Promise((resolve, reject) => {
 			output.getResultSummary(res, startTime);
 		}
 
-		if (program.summary) {
-			output.summary(res.obj(), {
-				json: program.json
-			});
-
-			return res;
-		}
-
-		if (program.depends) {
-			output.modules(res.depends(program.depends), {
-				json: program.json
-			});
-
-			return res;
-		}
-
-		if (program.orphans) {
-			output.modules(res.orphans(), {
-				json: program.json
-			});
-
-			return res;
-		}
-
-		if (program.leaves) {
-			output.modules(res.leaves(), {
-				json: program.json
-			});
-
-			return res;
-		}
-
-
-		if (program.circular) {
-			const circular = res.circular();
-
-			output.circular(spinner, res, circular, {
-				json: program.json
-			});
-
-			if (circular.length) {
-				exitCode = 1;
-			}
-
-			return res;
-		}
-
-		if (program.image) {
-			return res.image(program.image).then((imagePath) => {
-				spinner.succeed(`${chalk.bold('Image created at')} ${chalk.cyan.bold(imagePath)}`);
-				return res;
-			});
-		}
-
-		if (program.dot) {
-			return res.dot().then((output) => {
-				process.stdout.write(output);
-				return res;
-			});
+		const result = createOutputFromOptions(program, res);
+		if (result !== undefined) {
+			return result;
 		}
 
 		output.list(res.obj(), {
@@ -256,3 +200,65 @@ new Promise((resolve, reject) => {
 		console.log('\n%s %s\n', chalk.red('✖'), err.stack);
 		process.exit(1);
 	});
+
+function createOutputFromOptions(program, res) {
+	if (program.summary) {
+		output.summary(res.obj(), {
+			json: program.json
+		});
+
+		return res;
+	}
+
+	if (program.depends) {
+		output.modules(res.depends(program.depends), {
+			json: program.json
+		});
+
+		return res;
+	}
+
+	if (program.orphans) {
+		output.modules(res.orphans(), {
+			json: program.json
+		});
+
+		return res;
+	}
+
+	if (program.leaves) {
+		output.modules(res.leaves(), {
+			json: program.json
+		});
+
+		return res;
+	}
+
+	if (program.circular) {
+		const circular = res.circular();
+
+		output.circular(spinner, res, circular, {
+			json: program.json
+		});
+
+		if (circular.length) {
+			exitCode = 1;
+		}
+
+		return res;
+	}
+
+	if (program.image) {
+		return res.image(program.image).then((imagePath) => {
+			spinner.succeed(`${chalk.bold('Image created at')} ${chalk.cyan.bold(imagePath)}`);
+			return res;
+		});
+	}
+
+	if (program.dot) {
+		return res.dot().then((output) => {
+			process.stdout.write(output);
+			return res;
+		});
+	}
+}

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -22,6 +22,7 @@ program
 	.option('-i, --image <file>', 'write graph to file as an image')
 	.option('-l, --layout <name>', 'layout engine to use for graph (dot/neato/fdp/sfdp/twopi/circo)')
 	.option('--orphans', 'show modules that no one is depending on')
+	.option('--leaves', 'show modules that have no dependencies')
 	.option('--dot', 'show graph using the DOT language')
 	.option('--extensions <list>', 'comma separated string of valid file extensions')
 	.option('--require-config <file>', 'path to RequireJS config')
@@ -195,6 +196,15 @@ new Promise((resolve, reject) => {
 
 			return res;
 		}
+
+		if (program.leaves) {
+			output.modules(res.leaves(), {
+				json: program.json
+			});
+
+			return res;
+		}
+
 
 		if (program.circular) {
 			const circular = res.circular();

--- a/lib/api.js
+++ b/lib/api.js
@@ -136,19 +136,7 @@ class Madge {
 	*/
 	leaves() {
 		const tree = this.obj();
-		const map = {};
-
-		Object
-			.entries(tree)
-			.forEach(([key, value]) => {
-				if (!value.length) {
-					map[key] = true;
-				}
-			});
-
-		return Object
-			.keys(tree)
-			.filter((dep) => map[dep]);
+		return Object.keys(tree).filter((key) => !tree[key].length);
 	}
 
 	/**

--- a/lib/api.js
+++ b/lib/api.js
@@ -130,6 +130,28 @@ class Madge {
 	}
 
 	/**
+	* Return a list of modules that have no dependencies.
+	* @api public
+	* @return {Array}
+	*/
+	leaves() {
+		const tree = this.obj();
+		const map = {};
+
+		Object
+			.entries(tree)
+			.forEach(([key, value]) => {
+				if (!value.length) {
+					map[key] = true;
+				}
+			});
+
+		return Object
+			.keys(tree)
+			.filter((dep) => map[dep]);
+	}
+
+	/**
 	 * Return the module dependency graph as DOT output.
 	 * @api public
 	 * @return {Promise}

--- a/test/api.js
+++ b/test/api.js
@@ -235,6 +235,15 @@ describe('API', () => {
 		});
 	});
 
+	describe('leaves()', () => {
+		it('returns modules that have no dependencies', (done) => {
+			madge(__dirname + '/cjs/normal').then((res) => {
+				res.leaves().should.eql(['d.js']);
+				done();
+			}).catch(done);
+		});
+	});
+
 	describe('svg()', () => {
 		it('returns a promise resolved with XML SVG output in a Buffer', (done) => {
 			madge(__dirname + '/cjs/b.js')


### PR DESCRIPTION
The `--leaves` option is designed to show modules that do not have dependencies. It reports back modules normally shown in green, in the examples.

Resolves #242 
I changed the requested name to `leaves` as it makes more sense in the context of a tree structure.

**Note:** By adding one more if statement in `cli.js`, it broke two eslint rules. I didn't want to restructure your code so I've left it as-is to be changed later.

**Update:** I've slightly changed `cli.js` so the eslint rules weren't being violated. I tried to keep the change as minimal as possible - you can change it however you'd like.