### PR TITLE
Added support for combining --dot and --circular options

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -248,6 +248,13 @@ function createOutputFromOptions(program, res) {
 		});
 	}
 
+	if (program.dot) {
+		return res.dot(program.circular).then((output) => {
+			process.stdout.write(output);
+			return res;
+		});
+	}
+
 	if (program.circular) {
 		const circular = res.circular();
 
@@ -260,12 +267,5 @@ function createOutputFromOptions(program, res) {
 		}
 
 		return res;
-	}
-
-	if (program.dot) {
-		return res.dot().then((output) => {
-			process.stdout.write(output);
-			return res;
-		});
 	}
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -158,10 +158,15 @@ class Madge {
 	/**
 	 * Return the module dependency graph as DOT output.
 	 * @api public
+	 * @param  {Boolean} circularOnly
 	 * @return {Promise}
 	 */
-	dot() {
-		return graph.dot(this.obj(), this.circular(), this.config);
+	dot(circularOnly) {
+		return graph.dot(
+			circularOnly ? this.circularGraph() : this.obj(),
+			this.circular(),
+			this.config
+		);
 	}
 
 	/**


### PR DESCRIPTION
The changes are inspired by PR #224.

I tested it against my project and I successfully generated a `.dot` file that contains only circular dependencies.

I'm not familiar with the test files of this repository, So @pahen would you please review these changes and add some test cases to your project? and it would be great if you merge it any soon.

Thanks