### PR TITLE
Update ora to version 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "detective-stylus": "^1.0.0",
     "detective-typescript": "^5.8.0",
     "graphviz": "0.0.9",
-    "ora": "^4.0.4",
+    "ora": "^5.1.0",
     "pify": "^5.0.0",
     "pluralize": "^8.0.0",
     "precinct": "^6.3.1",


### PR DESCRIPTION
This improves deduplication since ora@4 requires chalk@3 while madge already required calk@4