### PR TITLE
Improve Graphviz support detection

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -28,7 +28,11 @@ async function checkGraphvizInstalled(config) {
 	try {
 		await exec(cmd, ['-V']);
 	} catch (err) {
-		throw new Error(`Graphviz could not be found. Ensure that "gvpr" is in your $PATH. ${err}`);
+		if (err.code === 'ENOENT') {
+			throw new Error(`Graphviz could not be found. Ensure that "gvpr" is in your $PATH. ${err}`);
+		} else {
+			throw new Error(`Unexpected error when calling Graphviz "${cmd}". ${err}`);
+		}
 	}
 }
 


### PR DESCRIPTION
Previous implementation was assuming that an error was always caused by
the Graphviz binary not available in the path.

However an error can also be thrown when Graphviz is missing
an external dependencies for example.

As far as I know ENOENT stands for a no entry error which
indicates that something wasn't found. In this case it should
be safe to assume that Graphviz isn't available in the path.

See: https://stackoverflow.com/q/66602685/1244884