### PR TITLE
feat: move typescript to an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "precinct": "^7.0.0",
     "pretty-ms": "^7.0.0",
     "rc": "^1.2.7",
-    "typescript": "^3.9.5",
     "walkdir": "^0.4.1"
   },
   "devDependencies": {
@@ -71,6 +70,12 @@
     "eslint": "^6.8.0",
     "mocha": "^8.0.1",
     "mz": "^2.7.0",
-    "should": "^13.2.3"
+    "should": "^13.2.3",
+    "typescript": "~4.1.5"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
This mirrors how typescript-estree depends on typescript:

https://github.com/typescript-eslint/typescript-eslint/blob/946ee3b68823a48fad2cb7b99589e56a68fb11e3/packages/typescript-estree/package.json#L69-L73

typescript-estree prints a warning if it doesn't like the currently
installed typescript version, which seems like good behaviour.

This has two advantages:

1) We don't have to update this library every time there's a new TS release
2) Better alignment with what the user is actually using.

And some disadvantages:
1) `npx madge` won't support typescript? Or will error on start. Can't test now, because this change would also need to be applied to e.g. detective-typescript.

NB: Typescript don't do semver, so the gap from 3.9 to 4.0 is the same as
the gap from 4.0 to 4.1 or 3.8 to 3.9.