### PR TITLE
feat: declare support for TS 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "precinct": "^7.0.0",
     "pretty-ms": "^7.0.0",
     "rc": "^1.2.7",
-    "typescript": "^3.9.5",
+    "typescript": "^3.9 || ^4",
     "walkdir": "^0.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Typescript don't do semver. 3.8 -> 3.9 is the same size of bump as 3.9 -> 4.0. We work fine on 4.0 and 4.1 and 4.2, and will likely work fine all the way to 5.0, so declare as such.

The main advantage of this is that users won't get (literally) 100MB added to their node_modules as two additional copies of `typescript` are installed.

A less aggressive version of https://github.com/pahen/madge/pull/275