### PR TITLE
Upgrade precinct to version 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "graphviz": "0.0.9",
     "ora": "^5.1.0",
     "pluralize": "^8.0.0",
-    "precinct": "^7.0.0",
+    "precinct": "^8.1.0",
     "pretty-ms": "^7.0.0",
     "rc": "^1.2.7",
     "typescript": "^3.9.5",


### PR DESCRIPTION
The only breaking change is a difference in CLI output, which doesn't impact `madge`: https://github.com/dependents/node-precinct/compare/v7.1.0...v8.1.0

It does however upgrade `detective-typescript` to version 7 so it'll deduplicate with the one that's a direct dependency from `madge`.