### PR TITLE
Allow for script to exit with code 0 even if circular dependencies are found

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,10 +310,16 @@ madge path/src/foo path/src/bar
 madge --extensions js,jsx path/src
 ```
 
-> Finding circular dependencies
+> Finding circular dependencies – exits 1 if any are found
 
 ```sh
 madge --circular path/src/app.js
+```
+
+> Finding circular dependencies – exits 0 if any are found
+
+```sh
+madge --circular --allow-circular path/src/app.js
 ```
 
 > Show modules that depends on a given module

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -37,6 +37,7 @@ program
 	.option('--stdin', 'read predefined tree from STDIN', false)
 	.option('--warning', 'show warnings about skipped files', false)
 	.option('--debug', 'turn on debug output', false)
+	.option('--allow-circular', 'exit with code 0 when circular dependencies are found', false)
 	.parse(process.argv);
 
 if (!program.args.length && !program.stdin) {
@@ -265,7 +266,7 @@ function createOutputFromOptions(program, res) {
 			json: program.json
 		});
 
-		if (circular.length) {
+		if (circular.length && !program.allowFailures) {
 			exitCode = 1;
 		}
 


### PR DESCRIPTION
In some cases, one might aim to use `madge` to get a list of circular dependencies without necessarily exiting `1` in the case that some are found. This PR adds an `--allow-circular` flag that will allow for that.