### PR TITLE
feat: add a hover effect for connected edges

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -24,6 +24,7 @@ const defaultConfig = {
 	noDependencyColor: '#cfffac',
 	cyclicNodeColor: '#ff6c60',
 	edgeColor: '#757575',
+	hoverEdgeColor: '#f9c5d7',
 	graphVizOptions: false,
 	graphVizPath: false,
 	dependencyFilter: false

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -125,7 +125,14 @@ function createGraph(modules, circular, config, options) {
 	let hoverStyles = Object.entries(edgeIndices).map(([id, deps]) => {
 		return Object.entries(deps)
 			.map(
-				([, edgeId]) => `#node${nodeIndices[id]}:hover~#edge${edgeId}>path {
+				([depId, edgeId]) => `#node${nodeIndices[depId]}:hover~#edge${edgeId}>path {
+stroke: ${config.hoverEdgeColor};
+}
+#node${nodeIndices[depId]}:hover~#edge${edgeId}>polygon {
+stroke: ${config.hoverEdgeColor};
+fill: ${config.hoverEdgeColor};
+}
+#node${nodeIndices[id]}:hover~#edge${edgeId}>path {
 stroke: ${config.hoverEdgeColor};
 }
 #node${nodeIndices[id]}:hover~#edge${edgeId}>polygon {

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -79,7 +79,7 @@ function createGraphvizOptions(config) {
  * @return {Promise}
  */
 function createGraph(modules, circular, config, options) {
-	const g = graphviz.digraph('G');
+	const g = graphviz.digraph('madge');
 	const nodes = {};
 	const cyclicModules = circular.reduce((a, b) => a.concat(b), []);
 
@@ -87,7 +87,16 @@ function createGraph(modules, circular, config, options) {
 		g.setGraphVizPath(config.graphVizPath);
 	}
 
+	const nodeIndices = {};
+	const edgeIndices = {};
+	// Graphviz starts counting at one
+	let nodeIndex = 1;
+	let edgeIndex = 1;
+
 	Object.keys(modules).forEach((id) => {
+		if (!nodes[id]) {
+			nodeIndices[id] = nodeIndex++;
+		}
 		nodes[id] = nodes[id] || g.addNode(id);
 
 		if (!modules[id].length) {
@@ -97,6 +106,10 @@ function createGraph(modules, circular, config, options) {
 		}
 
 		modules[id].forEach((depId) => {
+			if (!nodes[depId]) {
+				nodeIndices[depId] = nodeIndex++;
+			}
+
 			nodes[depId] = nodes[depId] || g.addNode(depId);
 
 			if (!modules[depId]) {
@@ -104,11 +117,37 @@ function createGraph(modules, circular, config, options) {
 			}
 
 			g.addEdge(nodes[id], nodes[depId]);
+			edgeIndices[id] = edgeIndices[id] || {};
+			edgeIndices[id][depId] = edgeIndex++;
 		});
 	});
 
+	let hoverStyles = Object.entries(edgeIndices).map(([id, deps]) => {
+		return Object.entries(deps)
+			.map(
+				([, edgeId]) => `#node${nodeIndices[id]}:hover~#edge${edgeId}>path {
+stroke: ${config.hoverEdgeColor};
+}
+#node${nodeIndices[id]}:hover~#edge${edgeId}>polygon {
+stroke: ${config.hoverEdgeColor};
+fill: ${config.hoverEdgeColor};
+}`)
+			.join('');
+	}).join('');
+
+	hoverStyles = `<style>
+${hoverStyles}
+</style>
+`;
+
 	return new Promise((resolve, reject) => {
-		g.output(options, resolve, (code, out, err) => {
+		g.output(options, (rendered) => {
+			const svgFooter = '</svg>\n\n';
+			const __b = Buffer.alloc(rendered.length + hoverStyles.length);
+			rendered.copy(__b, 0, 0, rendered.length - svgFooter.length);
+			__b.write(hoverStyles + svgFooter, rendered.length - svgFooter.length);
+			resolve(__b);
+		}, (code, out, err) => {
 			reject(new Error(err));
 		});
 	});

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -142,11 +142,15 @@ ${hoverStyles}
 
 	return new Promise((resolve, reject) => {
 		g.output(options, (rendered) => {
-			const svgFooter = '</svg>\n\n';
-			const __b = Buffer.alloc(rendered.length + hoverStyles.length);
-			rendered.copy(__b, 0, 0, rendered.length - svgFooter.length);
-			__b.write(hoverStyles + svgFooter, rendered.length - svgFooter.length);
-			resolve(__b);
+			if (options.type === 'svg') {
+				const svgFooter = '</svg>\n\n';
+				const __b = Buffer.alloc(rendered.length + hoverStyles.length);
+				rendered.copy(__b, 0, 0, rendered.length - svgFooter.length);
+				__b.write(hoverStyles + svgFooter, rendered.length - svgFooter.length);
+				resolve(__b);
+			} else {
+				resolve(rendered);
+			}
 		}, (code, out, err) => {
 			reject(new Error(err));
 		});

--- a/test/api.js
+++ b/test/api.js
@@ -232,7 +232,7 @@ describe('API', () => {
 		it('returns a promise resolved with graphviz DOT output', async () => {
 			const res = await madge(__dirname + '/cjs/b.js');
 			const output = await res.dot();
-			output.should.match(/digraph G/);
+			output.should.match(/digraph madge/);
 			output.should.match(/bgcolor="#111111"/);
 			output.should.match(/fontcolor="#c6c5fe"/);
 			output.should.match(/color="#757575"/);


### PR DESCRIPTION
This PR includes a custom stylesheet when emitting an `svg` file that highlights outgoing edges for the hovered node.
Does not fix any open issues that I am aware of.