### PR TITLE
feat: support for rankdir in CLI

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -27,6 +27,7 @@ program
 	.option('--orphans', 'show modules that no one is depending on')
 	.option('--leaves', 'show modules that have no dependencies')
 	.option('--dot', 'show graph using the DOT language')
+	.option('--rankdir <direction>', 'set the direction of the graph layout')
 	.option('--extensions <list>', 'comma separated string of valid file extensions')
 	.option('--require-config <file>', 'path to RequireJS config')
 	.option('--webpack-config <file>', 'path to webpack config')
@@ -128,6 +129,10 @@ if (!program.color) {
 	config.noDependencyColor = '#000000';
 	config.cyclicNodeColor = '#000000';
 	config.edgeColor = '#757575';
+}
+
+if (program.rankdir) {
+	config.rankdir = program.rankdir;
 }
 
 function dependencyFilter() {


### PR DESCRIPTION
Fixes #310 (opened by me), adding support for rankdir in the CLI using `--rankdir`. I'd be happy to have a go at adding in CLI support for the other missing configuration options if helpful