### PR TITLE
chore: bump detective-postcss to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "detective-cjs": "^3.1.1",
     "detective-es6": "^2.2.0",
     "detective-less": "^1.0.2",
-    "detective-postcss": "^5.0.0",
+    "detective-postcss": "^6.1.0",
     "detective-sass": "^3.0.1",
     "detective-scss": "^2.0.1",
     "detective-stylus": "^1.0.0",


### PR DESCRIPTION
## Why

When installing `madge` with `yarn` and `node v18.2.0`. This error was thrown

```
error detective-postcss@5.1.1: The engine "node" is incompatible with this module. Expected version "12.x || 14.x || 16.x". Got "18.2.0"
```

## How
I tried `yarn install` in a fork of this repo and it had the same error.
After  `yarn update detective-postcss@latest`, there's no more error on `yarn install` and `yarn test` still passes.
Please consider merge this PR (and better, add some dependency checker in this code base).

TIA