### PR TITLE
Feature: Interactive graph [as html page]

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,16 @@ madge --dot path/src/app.js > graph.gv
 madge --json path/src/app.js | tr '[a-z]' '[A-Z]' | madge --stdin
 ```
 
+# Interactive Controls
+`Left click` selects node(with edges) or edge. Other edges will be dimmed.
+
+`Left click` out of context(node or edge) resets everything to the initial state.
+
+`Right click` selects an additional node(with edges) or edge. Has no effect if there are no previously selected items.
+Previously selected nodes or edges will be slightly dimmed(but will stay colored).
+
+`Escape` resets everything to the initial state.
+
 # Debugging
 
 > To enable debugging output if you encounter problems, run madge with the `--debug` option then throw the result in a gist when creating issues on GitHub.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,20 @@ madge('path/to/app.js')
 	});
 ```
 
+#### .interactive(pagePath: string, [circularOnly: boolean])
+
+> Write the graph as an interactive html page to the given page path. Set `circularOnly` to only include circular dependencies. Returns a `Promise` resolved with a full path to the written page.
+
+```javascript
+const madge = require('madge');
+
+madge('path/to/app.js')
+	.then((res) => res.interactive('path/to/page.html'))
+	.then((writtenPagePath) => {
+		console.log('Page written to ' + writtenPagePath);
+	});
+```
+
 #### .svg()
 
 > Return a `Promise` resolved with the XML SVG representation of the dependency graph as a `Buffer`.
@@ -350,6 +364,12 @@ madge --image graph.svg path/src/app.js
 
 ```sh
 madge --circular --image graph.svg path/src/app.js
+```
+
+> Save graph as an interactive html page (requires [Graphviz](#graphviz-optional))
+
+```sh
+madge --interactive graph.html path/src/app.js
 ```
 
 > Save graph as a [DOT](http://en.wikipedia.org/wiki/DOT_language) file for further processing (requires [Graphviz](#graphviz-optional))

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -23,6 +23,7 @@ program
 	.option('-x, --exclude <regexp>', 'exclude modules using RegExp')
 	.option('-j, --json', 'output as JSON')
 	.option('-i, --image <file>', 'write graph to file as an image')
+	.option('-I, --interactive <file>', 'write graph to file as an interactive html page')
 	.option('-l, --layout <name>', 'layout engine to use for graph (dot/neato/fdp/sfdp/twopi/circo)')
 	.option('--orphans', 'show modules that no one is depending on')
 	.option('--leaves', 'show modules that have no dependencies')
@@ -247,6 +248,13 @@ function createOutputFromOptions(program, res) {
 	if (program.image) {
 		return res.image(program.image, program.circular).then((imagePath) => {
 			spinner.succeed(`${chalk.bold('Image created at')} ${chalk.cyan.bold(imagePath)}`);
+			return res;
+		});
+	}
+
+	if (program.interactive) {
+		return res.interactive(program.interactive, program.circular).then((pagePath) => {
+			spinner.succeed(`${chalk.bold('Html page created at')} ${chalk.cyan.bold(pagePath)}`);
 			return res;
 		});
 	}

--- a/lib/api.js
+++ b/lib/api.js
@@ -190,6 +190,26 @@ class Madge {
 	}
 
 	/**
+	 * Write dependency graph to interactive html page.
+	 * @api public
+	 * @param {String} pagePath
+	 * @param {Boolean} circularOnly
+	 * @return {Promise}
+	 */
+	interactive(pagePath, circularOnly) {
+		if (!pagePath) {
+			return Promise.reject(new Error('pagePath not provided'));
+		}
+
+		return graph.interactive(
+			circularOnly ? this.circularGraph() : this.obj(),
+			this.circular(),
+			pagePath,
+			this.config
+		);
+	}
+
+	/**
 	 * Return Buffer with XML SVG representation of the dependency graph.
 	 * @api public
 	 * @return {Promise}

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const {promisify} = require('util');
 const graphviz = require('graphviz');
+const interactive = require('./interactive');
 
 const exec = promisify(require('child_process').execFile);
 const writeFile = promisify(require('fs').writeFile);
@@ -121,14 +122,16 @@ function createGraph(modules, circular, config, options) {
  * @param  {Object} config
  * @return {Promise}
  */
-module.exports.svg = function (modules, circular, config) {
+function svg(modules, circular, config) {
 	const options = createGraphvizOptions(config);
 
 	options.type = 'svg';
 
 	return checkGraphvizInstalled(config)
 		.then(() => createGraph(modules, circular, config, options));
-};
+}
+
+module.exports.svg = svg;
 
 /**
  * Creates an image from the module dependency graph.
@@ -149,6 +152,21 @@ module.exports.image = function (modules, circular, imagePath, config) {
 				.then((image) => writeFile(imagePath, image))
 				.then(() => path.resolve(imagePath));
 		});
+};
+
+/**
+ * Creates an interactive html page from the module dependency graph.
+ * @param  {Object} modules
+ * @param  {Array} circular
+ * @param  {String} pagePath
+ * @param  {Object} config
+ * @return {Promise}
+ */
+module.exports.interactive = function (modules, circular, pagePath, config) {
+	return svg(modules, circular, config)
+		.then((svg) => interactive.generateInteractiveHtml(svg))
+		.then((page) => writeFile(pagePath, page))
+		.then(() => path.resolve(pagePath));
 };
 
 /**

--- a/lib/interactive/index.js
+++ b/lib/interactive/index.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const {resolve} = require('path');
+const {promisify} = require('util');
+const readFile = promisify(require('fs').readFile);
+
+function toHtml(styles, content, scripts) {
+	return `<!DOCTYPE html>
+<html lang="en" dir="ltr">
+	<head>
+		<meta charset="utf-8" />
+		<title>Interactive Graph</title>
+		<style>
+${styles}
+		</style>
+	</head>
+	<body>
+${content}
+		<script>
+${scripts}
+		</script>
+	</body>
+</html>
+	`;
+}
+
+module.exports.generateInteractiveHtml = function (svg) {
+	return Promise.all([
+		readFile(resolve(__dirname, './templates/styles.css')),
+		readFile(resolve(__dirname, './templates/scripts.js'))
+	]).then(([styles, scripts]) => toHtml(styles, svg, scripts));
+};

--- a/lib/interactive/templates/scripts.js
+++ b/lib/interactive/templates/scripts.js
@@ -1,0 +1,86 @@
+'use strict';
+
+/* eslint-disable no-undef */
+const SELECTED = 'selected';
+const DIMMED = 'dimmed';
+const FROM = 'from';
+const TO = 'to';
+
+const nodes = document.querySelectorAll('.node');
+const edges = document.querySelectorAll('.edge');
+
+const getTitleFrom = (el) => {
+	const titleElement = el.querySelector('title');
+	return titleElement ? titleElement.textContent.trim() : null;
+};
+const getEdgeDirections = (edgeTitle = '') => {
+	const [from = '', to = ''] = edgeTitle.split('->');
+	return {from: from.trim(), to: to.trim()};
+};
+
+const nodeTitleToNodeMap = new Map();
+
+for (const node of nodes) {
+	const title = getTitleFrom(node);
+	title && nodeTitleToNodeMap.set(title, node);
+}
+
+const edgesMap = new Map();
+
+for (const edge of edges) {
+	const title = getTitleFrom(edge);
+	const {from, to} = getEdgeDirections(title);
+
+	let nodeList = [nodeTitleToNodeMap.get(from), nodeTitleToNodeMap.get(to)];
+	edgesMap.set(title, nodeList);
+
+	nodeList = edgesMap.get(from) || [];
+	nodeList.push(edge);
+	edgesMap.set(from, nodeList);
+
+	nodeList = edgesMap.get(to) || [];
+	nodeList.push(edge);
+	edgesMap.set(to, nodeList);
+}
+
+let selectedTitle = null;
+
+document.addEventListener('click', ({target}) => {
+	const closest = target.closest('.edge, .node');
+
+	if (!closest) {
+		return resetAll();
+	}
+
+	const title = getTitleFrom(closest);
+
+	if (title === selectedTitle) {
+		return;
+	}
+
+	resetAll();
+	closest.classList.add(SELECTED);
+	edgesMap.get(title).forEach((edge) => {
+		edge.classList.add(SELECTED);
+		const {from} = getEdgeDirections(getTitleFrom(edge));
+		edge.classList.add(from === title ? FROM : TO);
+	});
+	document.querySelectorAll(`.edge:not(.${SELECTED})`)
+		.forEach((edge) => edge.classList.add(DIMMED));
+	selectedTitle = title;
+});
+
+
+function resetAll() {
+	selectedTitle = null;
+
+	document.querySelectorAll(`.edge:not(.${SELECTED})`)
+		.forEach((edge) => edge.classList.remove(DIMMED));
+
+	document.querySelectorAll(`.${SELECTED}`)
+		.forEach((node) => {
+			node.classList.remove(SELECTED);
+			node.classList.remove(TO);
+			node.classList.remove(FROM);
+		});
+}

--- a/lib/interactive/templates/scripts.js
+++ b/lib/interactive/templates/scripts.js
@@ -3,11 +3,10 @@
 /* eslint-disable no-undef */
 const SELECTED = 'selected';
 const DIMMED = 'dimmed';
+const CURRENT = 'current';
+const DUAL = 'dual';
 const FROM = 'from';
 const TO = 'to';
-
-const nodes = document.querySelectorAll('.node');
-const edges = document.querySelectorAll('.edge');
 
 const getTitleFrom = (el) => {
 	const titleElement = el.querySelector('title');
@@ -17,6 +16,30 @@ const getEdgeDirections = (edgeTitle = '') => {
 	const [from = '', to = ''] = edgeTitle.split('->');
 	return {from: from.trim(), to: to.trim()};
 };
+
+const resetAll = () => {
+	document.querySelectorAll(`.${DIMMED}`)
+		.forEach((edge) => edge.classList.remove(DIMMED));
+
+	document.querySelectorAll(`.${SELECTED}`)
+		.forEach((node) => {
+			node.classList.remove(SELECTED);
+			node.classList.remove(CURRENT);
+			node.classList.remove(TO);
+			node.classList.remove(FROM);
+			node.classList.remove(DUAL);
+		});
+};
+
+// prepend linear gradient:
+const svgEl = document.querySelector('svg');
+svgEl.insertAdjacentHTML('afterbegin', `<linearGradient id="dualDirection">
+<stop offset="0%" stop-color="var(--color-from)" />
+<stop offset="100%" stop-color="var(--color-to)" />
+</linearGradient>`);
+
+const nodes = document.querySelectorAll('.node');
+const edges = document.querySelectorAll('.edge');
 
 const nodeTitleToNodeMap = new Map();
 
@@ -43,8 +66,7 @@ for (const edge of edges) {
 	edgesMap.set(to, nodeList);
 }
 
-let selectedTitle = null;
-
+// select node or edge:
 document.addEventListener('click', ({target}) => {
 	const closest = target.closest('.edge, .node');
 
@@ -52,35 +74,62 @@ document.addEventListener('click', ({target}) => {
 		return resetAll();
 	}
 
-	const title = getTitleFrom(closest);
-
-	if (title === selectedTitle) {
+	if (closest.classList.contains(SELECTED)) {
 		return;
 	}
 
+	const title = getTitleFrom(closest);
+
 	resetAll();
 	closest.classList.add(SELECTED);
-	edgesMap.get(title).forEach((edge) => {
+	(edgesMap.get(title) || []).forEach((edge) => {
 		edge.classList.add(SELECTED);
 		const {from} = getEdgeDirections(getTitleFrom(edge));
 		edge.classList.add(from === title ? FROM : TO);
 	});
 	document.querySelectorAll(`.edge:not(.${SELECTED})`)
 		.forEach((edge) => edge.classList.add(DIMMED));
-	selectedTitle = title;
 });
 
+// add node or edge to already selected ones:
+document.addEventListener('contextmenu', (event) => {
+	event.preventDefault();
+	const hasSelected = Boolean(document.querySelector(`.${SELECTED}`));
+	if (!hasSelected) {
+		return;
+	}
 
-function resetAll() {
-	selectedTitle = null;
+	const closest = event.target.closest('.edge, .node');
 
-	document.querySelectorAll(`.edge:not(.${SELECTED})`)
-		.forEach((edge) => edge.classList.remove(DIMMED));
+	if (!closest || closest.classList.contains(SELECTED)) {
+		return;
+	}
 
-	document.querySelectorAll(`.${SELECTED}`)
-		.forEach((node) => {
-			node.classList.remove(SELECTED);
-			node.classList.remove(TO);
-			node.classList.remove(FROM);
-		});
-}
+	document.querySelectorAll(`.${CURRENT}`)
+		.forEach((node) => node.classList.remove(CURRENT));
+
+	closest.classList.remove(DIMMED);
+	closest.classList.add(SELECTED);
+	closest.classList.add(CURRENT);
+
+	const title = getTitleFrom(closest);
+	(edgesMap.get(title) || []).forEach((edge) => {
+		edge.classList.remove(DIMMED);
+		edge.classList.add(SELECTED);
+		edge.classList.add(CURRENT);
+		const {from, to} = getEdgeDirections(getTitleFrom(edge));
+
+		if (edge.classList.contains(FROM) && to === title) {
+			edge.classList.remove(FROM);
+			edge.classList.add(DUAL);
+		} else if (edge.classList.contains(TO) && from === title) {
+			edge.classList.remove(TO);
+			edge.classList.add(DUAL);
+		} else {
+			edge.classList.add(from === title ? FROM : TO);
+		}
+	});
+	document.querySelectorAll(`.edge:not(.${CURRENT})`)
+		.forEach((edge) => edge.classList.add(DIMMED));
+});
+

--- a/lib/interactive/templates/scripts.js
+++ b/lib/interactive/templates/scripts.js
@@ -133,3 +133,4 @@ document.addEventListener('contextmenu', (event) => {
 		.forEach((edge) => edge.classList.add(DIMMED));
 });
 
+document.addEventListener('keydown', ({key}) => key === 'Escape' && resetAll());

--- a/lib/interactive/templates/styles.css
+++ b/lib/interactive/templates/styles.css
@@ -4,28 +4,28 @@ svg {
 }
 
 .node, .edge {
-  stroke-width: 1.5;
+	stroke-width: 1.5;
 }
 
 .node.selected path, .node.selected polygon {
-  stroke-width: 4.5;
+	stroke-width: 4.5;
 }
 
 .edge.selected path, .edge.selected polygon {
-  stroke: blue;
-  stroke-width: 4.5;
+	stroke: blue;
+	stroke-width: 4.5;
 }
 
 .edge.selected polygon {
-  fill: blue;
+	fill: blue;
 }
 
 .edge.selected.from path, .edge.selected.from polygon {
-  stroke: yellow;
+	stroke: yellow;
 }
 
 .edge.selected.from polygon, .edge.selected.dual polygon {
-  fill: yellow;
+	fill: yellow;
 }
 
 .edge.selected.dual path {
@@ -38,9 +38,9 @@ svg {
 }
 
 .edge.dimmed path, .edge.dimmed polygon {
-  stroke-width: 1;
-  stroke-opacity: 0.3;
-  fill-opacity: 0.3;
+	stroke-width: 1;
+	stroke-opacity: 0.3;
+	fill-opacity: 0.3;
 }
 
 .edge.selected.dimmed path, .edge.selected.dimmed polygon {

--- a/lib/interactive/templates/styles.css
+++ b/lib/interactive/templates/styles.css
@@ -1,3 +1,8 @@
+svg {
+	width: 100%;
+	height: 100%;
+}
+
 .node, .edge {
   stroke-width: 1.5;
 }

--- a/lib/interactive/templates/styles.css
+++ b/lib/interactive/templates/styles.css
@@ -1,14 +1,14 @@
 .node, .edge {
-  stroke-width: 2;
+  stroke-width: 1.5;
 }
 
 .node.selected path, .node.selected polygon {
-  stroke-width: 4;
+  stroke-width: 4.5;
 }
 
 .edge.selected path, .edge.selected polygon {
   stroke: blue;
-  stroke-width: 4;
+  stroke-width: 4.5;
 }
 
 .edge.selected polygon {
@@ -19,14 +19,29 @@
   stroke: yellow;
 }
 
-.edge.selected.from polygon {
+.edge.selected.from polygon, .edge.selected.dual polygon {
   fill: yellow;
+}
+
+.edge.selected.dual path {
+	stroke: url(#dualDirection);
+}
+
+#dualDirection {
+	--color-from: yellow;
+	--color-to: blue;
 }
 
 .edge.dimmed path, .edge.dimmed polygon {
   stroke-width: 1;
   stroke-opacity: 0.3;
   fill-opacity: 0.3;
+}
+
+.edge.selected.dimmed path, .edge.selected.dimmed polygon {
+	stroke-width: 1.8;
+	stroke-opacity: 0.55;
+	fill-opacity: 0.55;
 }
 
 .node:hover, .edge:hover {

--- a/lib/interactive/templates/styles.css
+++ b/lib/interactive/templates/styles.css
@@ -1,0 +1,38 @@
+.node, .edge {
+  stroke-width: 2;
+}
+
+.node.selected path, .node.selected polygon {
+  stroke-width: 4;
+}
+
+.edge.selected path, .edge.selected polygon {
+  stroke: blue;
+  stroke-width: 4;
+}
+
+.edge.selected polygon {
+  fill: blue;
+}
+
+.edge.selected.from path, .edge.selected.from polygon {
+  stroke: yellow;
+}
+
+.edge.selected.from polygon {
+  fill: yellow;
+}
+
+.edge.dimmed path, .edge.dimmed polygon {
+  stroke-width: 1;
+  stroke-opacity: 0.3;
+  fill-opacity: 0.3;
+}
+
+.node:hover, .edge:hover {
+	cursor: pointer;
+}
+
+.edge:hover, .edge.dimmed path:hover, .edge.dimmed polygon:hover {
+	stroke-width: 10;
+}


### PR DESCRIPTION
Dear contributors,

Thank you for madge, this is a nice and easy-to-use library.
Recently, I forked madge and added an interactive feature for my personal needs.
I decided that this might be helpful for others as well. So here I am.

This feature is highly inspired by: https://github.com/sverweij/dependency-cruiser/blob/develop/src/cli/tools/wrap-stream-in-html.js

Please, check this deployed example based on the video.js open-source project (https://github.com/videojs/video.js):
https://dzianis-dashkevich.github.io/madge-interactive-examples/video-js-graph.html

Controls features (I added it to the README):
> `Left click` selects node(with edges) or edge. Other edges will be dimmed.
`Left click` out of context(node or edge) resets everything to the initial state.
`Right click` selects an additional node(with edges) or edge. Has no effect if there are no previously selected items.
Previously selected nodes or edges will be slightly dimmed(but will stay colored).
`Escape` resets everything to the initial state.

This example was generated by running the following command at the root of the project:
`npx madge --interactive interactive-graph.html src/js/video.js`

Currently, it is pretty opinionated (eg: colors, controls, etc..), we can discuss potential changes, if you are interested.
Please, just close this PR, If you are not interested in this feature.

Regards,
Dzianis