### PR TITLE
Handle collect tsconfig's extends fileds

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -111,13 +111,6 @@ if (program.tsConfig) {
 	config.tsConfig = program.tsConfig;
 }
 
-if (config.tsConfig) {
-	const ts = require('typescript');
-	const tsParsedConfig = ts.readJsonConfigFile(config.tsConfig, ts.sys.readFile);
-	const obj = ts.parseJsonSourceFileConfigFileContent(tsParsedConfig, ts.sys, path.dirname(config.tsConfig));
-	config.tsConfig = obj.raw;
-}
-
 if (program.includeNpm) {
 	config.includeNpm = program.includeNpm;
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path_ = require('path');
 const tree = require('./tree');
 const cyclic = require('./cyclic');
 const graph = require('./graph');
@@ -46,6 +47,16 @@ class Madge {
 		}
 
 		this.config = Object.assign({}, defaultConfig, config);
+		if (typeof this.config.tsConfig === 'string') {
+			const ts = require('typescript');
+			const tsParsedConfig = ts.readJsonConfigFile(this.config.tsConfig, ts.sys.readFile);
+			const obj = ts.parseJsonSourceFileConfigFileContent(tsParsedConfig, ts.sys, path_.dirname(config.tsConfig));
+			this.config.tsConfig = {
+				...obj.raw,
+				compilerOptions: obj.options
+			};
+			log('using tsconfig %o', this.config.tsConfig);
+		}
 
 		if (typeof path === 'object' && !Array.isArray(path)) {
 			this.tree = path;

--- a/test/typescript.js
+++ b/test/typescript.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const madge = require('../lib/api');
+const ts = require('typescript');
 require('should');
 
 describe('TypeScript', () => {
@@ -37,6 +38,22 @@ describe('TypeScript', () => {
 				'subfolder/index.ts': [],
 				'subfolder/require.tsx': ['subfolder2/export.ts'],
 				'subfolder2/export.ts': []
+			});
+			done();
+		}).catch(done);
+	});
+
+	it('got tsConfig as a string, "extends" field is interpreted', (done) => {
+		madge(dir + '/custom-paths/import.ts', {tsConfig: dir + '/with-config/tsconfig.json'}).then((res) => {
+			res.config.tsConfig.should.eql({
+				extends: './tsconfig.base.json',
+				compilerOptions: {
+					target: ts.ScriptTarget.ESNext,
+					module: ts.ModuleKind.CommonJS,
+					allowJs: true,
+					configFilePath: undefined
+				},
+				compileOnSave: undefined
 			});
 			done();
 		}).catch(done);

--- a/test/typescript/with-config/tsconfig.base.json
+++ b/test/typescript/with-config/tsconfig.base.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "target": "ES5",
+        "module": "CommonJS"
+    }
+}

--- a/test/typescript/with-config/tsconfig.json
+++ b/test/typescript/with-config/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.base.json",
+    "compilerOptions": {
+        "target": "ESNext",
+        "allowJs": true
+    }
+}


### PR DESCRIPTION
Resolved with the restriction that tsconfig is only resolved if specified by path to avoid breaking the API used by the user.

fix #323
