### PR TITLE
Move typescript to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,13 @@
     "ts-graphviz": "^1.5.0",
     "walkdir": "^0.4.1"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "typescript": "*"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@aptoma/eslint-config": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -65,8 +65,10 @@
     "rc": "^1.2.7",
     "stream-to-array": "^2.3.0",
     "ts-graphviz": "^1.5.0",
-    "typescript": "^3.9.5",
     "walkdir": "^0.4.1"
+  },
+  "optionalDependencies": {
+    "typescript": "*"
   },
   "devDependencies": {
     "@aptoma/eslint-config": "^7.0.1",
@@ -75,6 +77,7 @@
     "mocha": "^9.0.1",
     "mz": "^2.7.0",
     "release-it": "^15.6.0",
-    "should": "^13.2.3"
+    "should": "^13.2.3",
+    "typescript": "^4.5.5"
   }
 }


### PR DESCRIPTION
## What was the problem

Currently, the typescript package is used to load tsconfig and is not used by users who only use JavaScript.

The implementation is such that `require('typescript')` is actually done in the function, so it does not affect all users.

However, including it in the dependencies may restrict the version of TypeScript that can be used, and a warning may be displayed if a user specifies a different version when installing madge.

## Solution

Move the `typescript` dependency to the "peerDependencies" field and make the version specification a wildcard.

Also add the "peerDependenciesMeta" field and make typescript as optional. 

This is to avoid conflicts with the user's specification, and also because of the version specification in the directive `detective-typescript`, we expect to use the `typescript` version specified by the `detective-typescript` package, or the `typescript` version specified by the user, to be used when resolving the version. or the user-specified `typescript` version is expected to be used.

"peerDependencies" that specify only `typescript: *` can be ignored during development, so we specify typescript@^4.5.5, which is the same as the `detective-typescript@9.0.0` package.