### PR TITLE
Remove deploy to NPM from Travis build

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -3,9 +3,6 @@
 	"git": {
 		"requireCleanWorkingDir": false
 	},
-	"npm": {
-		"publish": false
-	},
 	"hooks": {
 		"after:bump": "auto-changelog --hide-credit --package"
 	}

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,3 @@ addons:
 script:
 - npm test
 - npm run debug
-deploy:
-  provider: npm
-  email: "patrik.henningsson@gmail.com"
-  api_key:
-    secure: nArcGw6OdS7J1bC+BuXk/2ER7z2Cc+Rjk0oBE/hoTsYo4+ry2LUzWM+nl28om5pF1xtXWwe0fb1rG4f3Ls28iHpH7E5Uz5+RfVfB4VH9w1HL4nBfLW5Ljj9J0ViQzSN1OPJ45B2lwHU8JH7N2c62FDJ5kqLn83WTGdb7Bgyau6o=
-  on:
-    tags: true

--- a/README.md
+++ b/README.md
@@ -375,8 +375,6 @@ npm test
 
 # Creating a release
 
-> Travis CI will automatically release the npm package to npmjs.com after a successful build.
-
 ```sh
 npm run release
 ```


### PR DESCRIPTION
It's now handled when running "npm run release" task instead. Will require user to be a maintainer on the NPM madge package. Also deleted to old access tokens used by the Travis build to access NPM.