### PR TITLE
Disable spinner when running in CI

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,12 +3,14 @@
 
 const path = require('path');
 const process = require('process');
-const program = require('commander');
+const {Command, Option} = require('commander');
 const rc = require('rc')('madge');
 const version = require('../package.json').version;
 const ora = require('ora');
 const chalk = require('chalk');
 const startTime = Date.now();
+
+const program = new Command();
 
 // Revert https://github.com/tj/commander.js/pull/1409
 program.storeOptionsAsProperties();
@@ -34,7 +36,7 @@ program
 	.option('--ts-config <file>', 'path to typescript config')
 	.option('--include-npm', 'include shallow NPM modules', false)
 	.option('--no-color', 'disable color in output and image', false)
-	.option('--no-spinner', 'disable progress spinner', false)
+	.addOption(new Option('--no-spinner', 'disable progress spinner', false).env('MADGE_NO_SPINNER'))
 	.option('--stdin', 'read predefined tree from STDIN', false)
 	.option('--warning', 'show warnings about skipped files', false)
 	.option('--debug', 'turn on debug output', false)

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,14 +3,13 @@
 
 const path = require('path');
 const process = require('process');
-const {Command, Option} = require('commander');
+const program = require('commander');
 const rc = require('rc')('madge');
 const version = require('../package.json').version;
 const ora = require('ora');
 const chalk = require('chalk');
 const startTime = Date.now();
-
-const program = new Command();
+const ci = require('ci-info');
 
 // Revert https://github.com/tj/commander.js/pull/1409
 program.storeOptionsAsProperties();
@@ -36,7 +35,7 @@ program
 	.option('--ts-config <file>', 'path to typescript config')
 	.option('--include-npm', 'include shallow NPM modules', false)
 	.option('--no-color', 'disable color in output and image', false)
-	.addOption(new Option('--no-spinner', 'disable progress spinner', false).env('MADGE_NO_SPINNER'))
+	.option('--no-spinner', 'disable progress spinner', false)
 	.option('--stdin', 'read predefined tree from STDIN', false)
 	.option('--warning', 'show warnings about skipped files', false)
 	.option('--debug', 'turn on debug output', false)
@@ -77,7 +76,8 @@ const spinner = ora({
 	text: 'Finding files',
 	color: 'white',
 	interval: 100000,
-	isEnabled: program.spinner
+	isEnabled: !ci.isCI && program.spinner,
+	isSilent: ci.isCI
 });
 
 let exitCode = 0;

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -9,7 +9,6 @@ const version = require('../package.json').version;
 const ora = require('ora');
 const chalk = require('chalk');
 const startTime = Date.now();
-const ci = require('ci-info');
 
 // Revert https://github.com/tj/commander.js/pull/1409
 program.storeOptionsAsProperties();
@@ -76,8 +75,7 @@ const spinner = ora({
 	text: 'Finding files',
 	color: 'white',
 	interval: 100000,
-	isEnabled: !ci.isCI && program.spinner,
-	isSilent: ci.isCI
+	isEnabled: program.spinner === 'false' ? false : null
 });
 
 let exitCode = 0;
@@ -139,10 +137,8 @@ function dependencyFilter() {
 			const dir = path.dirname(relPath) + '/';
 			const file = path.basename(relPath);
 
-			if (program.spinner) {
-				spinner.text = chalk.grey(dir) + chalk.cyan(file);
-				spinner.render();
-			}
+			spinner.text = chalk.grey(dir) + chalk.cyan(file);
+
 			prevFile = traversedFilePath;
 		}
 	};

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "debug": "node bin/cli.js --debug bin lib",
     "generate": "npm run generate:small && npm run generate:madge",
     "generate:small": "bin/cli.js --image /tmp/simple.svg test/cjs/circular/a.js",
-    "generate:madge": "bin/cli.js --image /tmp/madge.svg bin lib",
+    "generate:madge": "export CI=true; bin/cli.js --image /tmp/madge.svg bin lib",
     "test:output": "./test/output.sh",
     "release": "npm test && release-it"
   },
@@ -45,7 +45,8 @@
   },
   "dependencies": {
     "chalk": "^4.1.1",
-    "commander": "^8.2.0",
+    "ci-info": "^3.7.1",
+    "commander": "^7.2.0",
     "commondir": "^1.0.1",
     "debug": "^4.3.1",
     "dependency-tree": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   },
   "dependencies": {
     "chalk": "^4.1.1",
-    "ci-info": "^3.7.1",
     "commander": "^7.2.0",
     "commondir": "^1.0.1",
     "debug": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "debug": "node bin/cli.js --debug bin lib",
     "generate": "npm run generate:small && npm run generate:madge",
     "generate:small": "bin/cli.js --image /tmp/simple.svg test/cjs/circular/a.js",
-    "generate:madge": "export CI=true; bin/cli.js --image /tmp/madge.svg bin lib",
+    "generate:madge": "bin/cli.js --image /tmp/madge.svg bin lib",
     "test:output": "./test/output.sh",
     "release": "npm test && release-it"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.1",
-    "commander": "^7.2.0",
+    "commander": "^8.2.0",
     "commondir": "^1.0.1",
     "debug": "^4.3.1",
     "dependency-tree": "^9.0.0",


### PR DESCRIPTION
Added support for disabling the spinner via an env var to make the output more CI-friendly.

For that, I updated commander to version [8.2.0](https://github.com/tj/commander.js/releases/tag/v8.2.0), which added support for option values via env vars.