### PR TITLE
Update docs to better support typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,10 +316,10 @@ madge --circular path/src/app.js
 madge --depends wheels.js path/src/app.js
 ```
 
-> Show modules that no one is depending on
+> Show modules that no one is depending on. Only scans files with the current `--extensions`.
 
 ```sh
-madge --orphans path/src/
+madge --extensions ts,tsx,js,jsx --orphans path/src/
 ```
 
 > Show modules that have no dependencies


### PR DESCRIPTION
Since the default extensions scanned with the `--orphans` CLI option are only `js` files, running this in a typescript project yields confusingly zero results. Explicitly mentioning that this uses the `--extensions` makes this more obvious when trying to use madge.