### PR TITLE
constrain and bump typescript versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "walkdir": "^0.4.1"
   },
   "peerDependencies": {
-    "typescript": "*"
+    "typescript": "^3.9.5 || ^4.9.5 || ^5"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "mz": "^2.7.0",
     "release-it": "^15.6.0",
     "should": "^13.2.3",
-    "typescript": "^4.5.5"
+    "typescript": "^4.9.5"
   }
 }


### PR DESCRIPTION
The latest publicly released version of `madge` has a runtime dependency of `typescript@^3.9.5`. #350 moved it to `peerDependencies` and lifted the version range to `*`.

This PR proposes to constrain the `typescript`versions supported in `peerDependencies` to either of:

- `^3.9.5` (backwards-compat with `madge`@`6.0.0`)
- `^5` (supporting current version makes sense if it already works)
- `^4.9.5` (only makes sense considering the above but don't support legacy `4.x`)

The intention here is to reduce the range of supported versions to make it more feasible to test for, as well as the risk of future regressions or unplanned breaking changes.