### PR TITLE
Adding option to not print the index

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -35,6 +35,7 @@ program
 	.option('--include-npm', 'include shallow NPM modules', false)
 	.option('--no-color', 'disable color in output and image', false)
 	.option('--no-spinner', 'disable progress spinner', false)
+	.option('--no-index', 'disable index in output', false)
 	.option('--stdin', 'read predefined tree from STDIN', false)
 	.option('--warning', 'show warnings about skipped files', false)
 	.option('--debug', 'turn on debug output', false)
@@ -258,7 +259,8 @@ function createOutputFromOptions(program, res) {
 		const circular = res.circular();
 
 		output.circular(spinner, res, circular, {
-			json: program.json
+			json: program.json,
+			index: program.index
 		});
 
 		if (circular.length) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -35,7 +35,7 @@ program
 	.option('--include-npm', 'include shallow NPM modules', false)
 	.option('--no-color', 'disable color in output and image', false)
 	.option('--no-spinner', 'disable progress spinner', false)
-	.option('--no-index', 'disable index in output', false)
+	.option('--no-count', 'disable circular dependencies counting', false)
 	.option('--stdin', 'read predefined tree from STDIN', false)
 	.option('--warning', 'show warnings about skipped files', false)
 	.option('--debug', 'turn on debug output', false)
@@ -260,7 +260,7 @@ function createOutputFromOptions(program, res) {
 
 		output.circular(spinner, res, circular, {
 			json: program.json,
-			index: program.index
+			printCount: program.count
 		});
 
 		if (circular.length) {

--- a/lib/output.js
+++ b/lib/output.js
@@ -80,7 +80,7 @@ module.exports.circular = function (spinner, res, circular, opts) {
 	} else {
 		spinner.fail(chalk.red.bold(`Found ${pluralize('circular dependency', cyclicCount, true)}!\n`));
 		circular.forEach((path, idx) => {
-			if (opts.idx) {
+			if (opts.index) {
 				process.stdout.write(chalk.dim(idx + 1 + ') '));
 			}
 			path.forEach((module, idx) => {

--- a/lib/output.js
+++ b/lib/output.js
@@ -80,7 +80,7 @@ module.exports.circular = function (spinner, res, circular, opts) {
 	} else {
 		spinner.fail(chalk.red.bold(`Found ${pluralize('circular dependency', cyclicCount, true)}!\n`));
 		circular.forEach((path, idx) => {
-			if (opts.index) {
+			if (opts.printCount) {
 				process.stdout.write(chalk.dim(idx + 1 + ') '));
 			}
 			path.forEach((module, idx) => {

--- a/lib/output.js
+++ b/lib/output.js
@@ -80,7 +80,9 @@ module.exports.circular = function (spinner, res, circular, opts) {
 	} else {
 		spinner.fail(chalk.red.bold(`Found ${pluralize('circular dependency', cyclicCount, true)}!\n`));
 		circular.forEach((path, idx) => {
-			process.stdout.write(chalk.dim(idx + 1 + ') '));
+			if (opts.idx) {
+				process.stdout.write(chalk.dim(idx + 1 + ') '));
+			}
 			path.forEach((module, idx) => {
 				if (idx) {
 					process.stdout.write(chalk.dim(' > '));

--- a/test/output.sh
+++ b/test/output.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
 function desc() {
-	echo "\033[01;38;5;022m############### $1 ###############\033[0m";
+	echo "\033[01;38;5;022m############### $1 ###############\033[0m"
 }
 
 desc "LIST"
@@ -16,7 +16,10 @@ desc "DEPENDS"
 desc "CIRCULAR (OK)"
 ./bin/cli.js test/cjs/a.js -c
 
-desc "CIRCULAR (FOUND)"
+desc "CIRCULAR (FOUND, NO INDEX COUNTING)"
+./bin/cli.js test/cjs/circular/a.js -c --no-count
+
+desc "CIRCULAR (FOUND, WITH INDEX COUNT)"
 ./bin/cli.js test/cjs/circular/a.js -c
 
 desc "NPM"


### PR DESCRIPTION
As it is very helpful to sort the lines in the output of a circular dependency output file, I have added this option. This makes sorting the file easier as I do not have to remove hundreds of lines of indices first. With sorted files, reading the output and understanding big bottlenecks easier.