### PR TITLE
BREAKING: Drop support for Node.js 14-15,17,19

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
 
     runs-on: ${{ matrix.os }}
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "graph"
   ],
   "engines": {
-    "node": ">=14"
+    "node": "^16.20 || ^18.16 || >=20"
   },
   "main": "./lib/api",
   "bin": {


### PR DESCRIPTION
While the package itself still runs on node 14, `release-it` bump from 15 to 16 introduced devDependencies with minimum Node.js version 16.

Node.js 14 is EoL as of 2023-04-30.