### PR TITLE
Update to dependency-tree@11

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{package.json,.travis.yml}]
+[{package.json,.travis.yml,.github/**/*.yml}]
 indent_style = space
 indent_size = 2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,18 +7,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: ${{ matrix.os }} / Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
+          cache: "npm"
           node-version: ${{ matrix.node-version }}
-
       - name: npm install, build, and test
         run: |
           sudo apt install -y --no-install-recommends graphviz

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,7 +17,6 @@ jobs:
       - name: ${{ matrix.os }} / Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          cache: "npm"
           node-version: ${{ matrix.node-version }}
       - name: npm install, build, and test
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "commander": "^7.2.0",
         "commondir": "^1.0.1",
         "debug": "^4.3.4",
-        "dependency-tree": "^10.0.9",
+        "dependency-tree": "^11.0.0",
         "ora": "^5.4.1",
         "pluralize": "^8.0.0",
         "precinct": "^11.0.5",
@@ -159,9 +159,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
+      "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -222,6 +222,11 @@
       "version": "2.2.5",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@ljharb/through": {
       "version": "2.3.11",
@@ -591,6 +596,57 @@
       "version": "1.1.2",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.27.tgz",
+      "integrity": "sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==",
+      "dependencies": {
+        "@babel/parser": "^7.24.4",
+        "@vue/shared": "3.4.27",
+        "entities": "^4.5.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
+      "integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
+      "dependencies": {
+        "@vue/compiler-core": "3.4.27",
+        "@vue/shared": "3.4.27"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.27.tgz",
+      "integrity": "sha512-nDwntUEADssW8e0rrmE0+OrONwmRlegDA1pD6QhVeXxjIytV03yDqTey9SBDiALsvAd5U4ZrEKbMyVXhX6mCGA==",
+      "dependencies": {
+        "@babel/parser": "^7.24.4",
+        "@vue/compiler-core": "3.4.27",
+        "@vue/compiler-dom": "3.4.27",
+        "@vue/compiler-ssr": "3.4.27",
+        "@vue/shared": "3.4.27",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.10",
+        "postcss": "^8.4.38",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.27.tgz",
+      "integrity": "sha512-CVRzSJIltzMG5FcidsW0jKNQnNRYC8bT21VegyMMtHmhW3UOI7knmUehzswXLrExDLE6lQCZdrhD4ogI7c+vuw==",
+      "dependencies": {
+        "@vue/compiler-dom": "3.4.27",
+        "@vue/shared": "3.4.27"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.27.tgz",
+      "integrity": "sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA=="
     },
     "node_modules/acorn": {
       "version": "7.4.1",
@@ -1626,28 +1682,347 @@
       }
     },
     "node_modules/dependency-tree": {
-      "version": "10.0.9",
-      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-10.0.9.tgz",
-      "integrity": "sha512-dwc59FRIsht+HfnTVM0BCjJaEWxdq2YAvEDy4/Hn6CwS3CBWMtFnL3aZGAkQn3XCYxk/YcTDE4jX2Q7bFTwCjA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-11.0.1.tgz",
+      "integrity": "sha512-eCt7HSKIC9NxgIykG2DRq3Aewn9UhVS14MB3rEn6l/AsEI1FBg6ZGSlCU0SZ6Tjm2kkhj6/8c2pViinuyKELhg==",
       "dependencies": {
-        "commander": "^10.0.1",
-        "filing-cabinet": "^4.1.6",
-        "precinct": "^11.0.5",
-        "typescript": "^5.0.4"
+        "commander": "^12.0.0",
+        "filing-cabinet": "^5.0.1",
+        "precinct": "^12.0.2",
+        "typescript": "^5.4.5"
       },
       "bin": {
         "dependency-tree": "bin/cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/@dependents/detective-less": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@dependents/detective-less/-/detective-less-5.0.0.tgz",
+      "integrity": "sha512-D/9dozteKcutI5OdxJd8rU+fL6XgaaRg60sPPJWkT33OCiRfkCu5wO5B/yXTaaL2e6EB0lcCBGe5E0XscZCvvQ==",
+      "dependencies": {
+        "gonzales-pe": "^4.3.0",
+        "node-source-walk": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/@typescript-eslint/types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.10.0.tgz",
+      "integrity": "sha512-7fNj+Ya35aNyhuqrA1E/VayQX9Elwr8NKZ4WueClR3KwJ7Xx9jcCdOrLW04h51de/+gNbyFMs+IDxh5xIwfbNg==",
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.10.0.tgz",
+      "integrity": "sha512-LXFnQJjL9XIcxeVfqmNj60YhatpRLt6UhdlFwAkjNc6jSUlK8zQOl1oktAP8PlWFzPQC1jny/8Bai3/HPuvN5g==",
+      "dependencies": {
+        "@typescript-eslint/types": "7.10.0",
+        "@typescript-eslint/visitor-keys": "7.10.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dependency-tree/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.10.0.tgz",
+      "integrity": "sha512-9ntIVgsi6gg6FIq9xjEO4VQJvwOqA3jaBFQJ/6TK5AvEup2+cECI6Fh7QiBxmfMHXU0V0J4RyPeOU1VDNzl9cg==",
+      "dependencies": {
+        "@typescript-eslint/types": "7.10.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/ast-module-types": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-6.0.0.tgz",
+      "integrity": "sha512-LFRg7178Fw5R4FAEwZxVqiRI8IxSM+Ay2UBrHoCerXNme+kMMMfz7T3xDGV/c2fer87hcrtgJGsnSOfUrPK6ng==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/dependency-tree/node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/detective-amd": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-6.0.0.tgz",
+      "integrity": "sha512-NTqfYfwNsW7AQltKSEaWR66hGkTeD52Kz3eRQ+nfkA9ZFZt3iifRCWh+yZ/m6t3H42JFwVFTrml/D64R2PAIOA==",
+      "dependencies": {
+        "ast-module-types": "^6.0.0",
+        "escodegen": "^2.1.0",
+        "get-amd-module-type": "^6.0.0",
+        "node-source-walk": "^7.0.0"
+      },
+      "bin": {
+        "detective-amd": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/detective-cjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-6.0.0.tgz",
+      "integrity": "sha512-R55jTS6Kkmy6ukdrbzY4x+I7KkXiuDPpFzUViFV/tm2PBGtTCjkh9ZmTuJc1SaziMHJOe636dtiZLEuzBL9drg==",
+      "dependencies": {
+        "ast-module-types": "^6.0.0",
+        "node-source-walk": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/detective-es6": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-5.0.0.tgz",
+      "integrity": "sha512-NGTnzjvgeMW1khUSEXCzPDoraLenWbUjCFjwxReH+Ir+P6LGjYtaBbAvITWn2H0VSC+eM7/9LFOTAkrta6hNYg==",
+      "dependencies": {
+        "node-source-walk": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/detective-postcss": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-7.0.0.tgz",
+      "integrity": "sha512-pSXA6dyqmBPBuERpoOKKTUUjQCZwZPLRbd1VdsTbt6W+m/+6ROl4BbE87yQBUtLoK7yX8pvXHdKyM/xNIW9F7A==",
+      "dependencies": {
+        "is-url": "^1.2.4",
+        "postcss-values-parser": "^6.0.2"
+      },
+      "engines": {
+        "node": "^14.0.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.38"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/detective-sass": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-6.0.0.tgz",
+      "integrity": "sha512-h5GCfFMkPm4ZUUfGHVPKNHKT8jV7cSmgK+s4dgQH4/dIUNh9/huR1fjEQrblOQNDalSU7k7g+tiW9LJ+nVEUhg==",
+      "dependencies": {
+        "gonzales-pe": "^4.3.0",
+        "node-source-walk": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/detective-scss": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-5.0.0.tgz",
+      "integrity": "sha512-Y64HyMqntdsCh1qAH7ci95dk0nnpA29g319w/5d/oYcHolcGUVJbIhOirOFjfN1KnMAXAFm5FIkZ4l2EKFGgxg==",
+      "dependencies": {
+        "gonzales-pe": "^4.3.0",
+        "node-source-walk": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/detective-stylus": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-5.0.0.tgz",
+      "integrity": "sha512-KMHOsPY6aq3196WteVhkY5FF+6Nnc/r7q741E+Gq+Ax9mhE2iwj8Hlw8pl+749hPDRDBHZ2WlgOjP+twIG61vQ==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/detective-typescript": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-13.0.0.tgz",
+      "integrity": "sha512-tcMYfiFWoUejSbvSblw90NDt76/4mNftYCX0SMnVRYzSXv8Fvo06hi4JOPdNvVNxRtCAKg3MJ3cBJh+ygEMH+A==",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "^7.6.0",
+        "ast-module-types": "^6.0.0",
+        "node-source-walk": "^7.0.0"
+      },
+      "engines": {
+        "node": "^14.14.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.4.4"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/detective-vue2": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detective-vue2/-/detective-vue2-2.0.1.tgz",
+      "integrity": "sha512-EGHcIFCEPGO7MExgRZA8LqHQsKakjzrd96V358PV3WGFl+ibzNlYP/Msav43jBiCC5TpjWcy1FFUekrzXQM1Fg==",
+      "dependencies": {
+        "@vue/compiler-sfc": "^3.4.21",
+        "detective-es6": "^5.0.0",
+        "detective-sass": "^6.0.0",
+        "detective-scss": "^5.0.0",
+        "detective-stylus": "^5.0.0",
+        "detective-typescript": "^13.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "typescript": "^5.4.4"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/get-amd-module-type": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-6.0.0.tgz",
+      "integrity": "sha512-hFM7oivtlgJ3d6XWD6G47l8Wyh/C6vFw5G24Kk1Tbq85yh5gcM8Fne5/lFhiuxB+RT6+SI7I1ThB9lG4FBh3jw==",
+      "dependencies": {
+        "ast-module-types": "^6.0.0",
+        "node-source-walk": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/module-definition": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-6.0.0.tgz",
+      "integrity": "sha512-sEGP5nKEXU7fGSZUML/coJbrO+yQtxcppDAYWRE9ovWsTbFoUHB2qDUx564WUzDaBHXsD46JBbIK5WVTwCyu3w==",
+      "dependencies": {
+        "ast-module-types": "^6.0.0",
+        "node-source-walk": "^7.0.0"
+      },
+      "bin": {
+        "module-definition": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/node-source-walk": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-7.0.0.tgz",
+      "integrity": "sha512-1uiY543L+N7Og4yswvlm5NCKgPKDEXd9AUR9Jh3gen6oOeBsesr6LqhXom1er3eRzSUcVRWXzhv8tSNrIfGHKw==",
+      "dependencies": {
+        "@babel/parser": "^7.24.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/precinct": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/precinct/-/precinct-12.1.1.tgz",
+      "integrity": "sha512-Vmmtp0QdtM0Z5NzkRG09AgUgBwOpG0KW9KvG1vkltx+e2zrGCWbM5661f6lf8YjKbJhM39TICA6Wc36ZzX1PqQ==",
+      "dependencies": {
+        "@dependents/detective-less": "^5.0.0",
+        "commander": "^12.0.0",
+        "detective-amd": "^6.0.0",
+        "detective-cjs": "^6.0.0",
+        "detective-es6": "^5.0.0",
+        "detective-postcss": "^7.0.0",
+        "detective-sass": "^6.0.0",
+        "detective-scss": "^5.0.0",
+        "detective-stylus": "^5.0.0",
+        "detective-typescript": "^13.0.0",
+        "detective-vue2": "^2.0.0",
+        "module-definition": "^6.0.0",
+        "node-source-walk": "^7.0.0",
+        "postcss": "^8.4.38",
+        "typescript": "^5.4.5"
+      },
+      "bin": {
+        "precinct": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/deprecation": {
@@ -1810,9 +2185,9 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
-      "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.1.tgz",
+      "integrity": "sha512-4U5pNsuDl0EhuZpq46M5xPslstkviJuhrdobaRDBk2Jy2KO37FDAJl4lb2KlNabxT0m4MTK2UHNrsAcphE8nyw==",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -1831,6 +2206,17 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -2161,6 +2547,11 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "license": "BSD-2-Clause",
@@ -2343,36 +2734,81 @@
       }
     },
     "node_modules/filing-cabinet": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-4.1.6.tgz",
-      "integrity": "sha512-C+HZbuQTER36sKzGtUhrAPAoK6+/PrrUhYDBQEh3kBRdsyEhkLbp1ML8S0+6e6gCUrUlid+XmubxJrhvL2g/Zw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-5.0.2.tgz",
+      "integrity": "sha512-RZlFj8lzyu6jqtFBeXNqUjjNG6xm+gwXue3T70pRxw1W40kJwlgq0PSWAmh0nAnn5DHuBIecLXk9+1VKS9ICXA==",
       "dependencies": {
         "app-module-path": "^2.2.0",
-        "commander": "^10.0.1",
-        "enhanced-resolve": "^5.14.1",
-        "is-relative-path": "^1.0.2",
-        "module-definition": "^5.0.1",
-        "module-lookup-amd": "^8.0.5",
-        "resolve": "^1.22.3",
-        "resolve-dependency-path": "^3.0.2",
-        "sass-lookup": "^5.0.1",
-        "stylus-lookup": "^5.0.1",
+        "commander": "^12.0.0",
+        "enhanced-resolve": "^5.16.0",
+        "module-definition": "^6.0.0",
+        "module-lookup-amd": "^9.0.1",
+        "resolve": "^1.22.8",
+        "resolve-dependency-path": "^4.0.0",
+        "sass-lookup": "^6.0.1",
+        "stylus-lookup": "^6.0.0",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.0.4"
+        "typescript": "^5.4.4"
       },
       "bin": {
         "filing-cabinet": "bin/cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
+      }
+    },
+    "node_modules/filing-cabinet/node_modules/ast-module-types": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-6.0.0.tgz",
+      "integrity": "sha512-LFRg7178Fw5R4FAEwZxVqiRI8IxSM+Ay2UBrHoCerXNme+kMMMfz7T3xDGV/c2fer87hcrtgJGsnSOfUrPK6ng==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/filing-cabinet/node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
+      }
+    },
+    "node_modules/filing-cabinet/node_modules/module-definition": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-6.0.0.tgz",
+      "integrity": "sha512-sEGP5nKEXU7fGSZUML/coJbrO+yQtxcppDAYWRE9ovWsTbFoUHB2qDUx564WUzDaBHXsD46JBbIK5WVTwCyu3w==",
+      "dependencies": {
+        "ast-module-types": "^6.0.0",
+        "node-source-walk": "^7.0.0"
+      },
+      "bin": {
+        "module-definition": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/filing-cabinet/node_modules/node-source-walk": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-7.0.0.tgz",
+      "integrity": "sha512-1uiY543L+N7Og4yswvlm5NCKgPKDEXd9AUR9Jh3gen6oOeBsesr6LqhXom1er3eRzSUcVRWXzhv8tSNrIfGHKw==",
+      "dependencies": {
+        "@babel/parser": "^7.24.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/filing-cabinet/node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/fill-range": {
@@ -3448,11 +3884,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-relative-path": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-relative-path/-/is-relative-path-1.0.2.tgz",
-      "integrity": "sha512-i1h+y50g+0hRbBD+dbnInl3JlJ702aar58snAeX+MxBAPvzXGej7sYoPMhlnykabt0ZzCJNBEyzMlekuQZN7fA=="
-    },
     "node_modules/is-set": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
@@ -3859,6 +4290,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.10",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "dev": true,
@@ -4079,11 +4518,11 @@
       }
     },
     "node_modules/module-lookup-amd": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-8.0.5.tgz",
-      "integrity": "sha512-vc3rYLjDo5Frjox8NZpiyLXsNWJ5BWshztc/5KSOMzpg9k5cHH652YsJ7VKKmtM4SvaxuE9RkrYGhiSjH3Ehow==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-9.0.1.tgz",
+      "integrity": "sha512-MFeZCK6j2k7fXlldyZ1FgA5goTmvLF0BCQKkxzapsvsPqhCM6NvanE0vy9x5HpY5ETF1yo+PCB9TZIow3PABYg==",
       "dependencies": {
-        "commander": "^10.0.1",
+        "commander": "^12.0.0",
         "glob": "^7.2.3",
         "requirejs": "^2.3.6",
         "requirejs-config-file": "^4.0.0"
@@ -4092,15 +4531,15 @@
         "lookup-amd": "bin/cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/module-lookup-amd/node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/ms": {
@@ -4622,9 +5061,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "funding": [
         {
           "type": "opencollective",
@@ -4640,9 +5079,9 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -4665,9 +5104,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
@@ -5423,8 +5862,9 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.4",
-      "license": "MIT",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -5443,11 +5883,11 @@
       "license": "MIT"
     },
     "node_modules/resolve-dependency-path": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/resolve-dependency-path/-/resolve-dependency-path-3.0.2.tgz",
-      "integrity": "sha512-Tz7zfjhLfsvR39ADOSk9us4421J/1ztVBo4rWUkF38hgHK5m0OCZ3NxFVpqHRkjctnwVa15igEUHFJp8MCS7vA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-dependency-path/-/resolve-dependency-path-4.0.0.tgz",
+      "integrity": "sha512-hlY1SybBGm5aYN3PC4rp15MzsJLM1w+MEA/4KU3UBPfz4S0lL3FL6mgv7JgaA8a+ZTeEQAiF1a1BuN2nkqiIlg==",
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/resolve-from": {
@@ -5625,25 +6065,25 @@
       "dev": true
     },
     "node_modules/sass-lookup": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-5.0.1.tgz",
-      "integrity": "sha512-t0X5PaizPc2H4+rCwszAqHZRtr4bugo4pgiCvrBFvIX0XFxnr29g77LJcpyj9A0DcKf7gXMLcgvRjsonYI6x4g==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-6.0.1.tgz",
+      "integrity": "sha512-nl9Wxbj9RjEJA5SSV0hSDoU2zYGtE+ANaDS4OFUR7nYrquvBFvPKZZtQHe3lvnxCcylEDV00KUijjdMTUElcVQ==",
       "dependencies": {
-        "commander": "^10.0.1"
+        "commander": "^12.0.0"
       },
       "bin": {
         "sass-lookup": "bin/cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/sass-lookup/node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/semver": {
@@ -5888,9 +6328,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6096,25 +6536,25 @@
       }
     },
     "node_modules/stylus-lookup": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-5.0.1.tgz",
-      "integrity": "sha512-tLtJEd5AGvnVy4f9UHQMw4bkJJtaAcmo54N+ovQBjDY3DuWyK9Eltxzr5+KG0q4ew6v2EHyuWWNnHeiw/Eo7rQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-6.0.0.tgz",
+      "integrity": "sha512-RaWKxAvPnIXrdby+UWCr1WRfa+lrPMSJPySte4Q6a+rWyjeJyFOLJxr5GrAVfcMCsfVlCuzTAJ/ysYT8p8do7Q==",
       "dependencies": {
-        "commander": "^10.0.1"
+        "commander": "^12.0.0"
       },
       "bin": {
         "stylus-lookup": "bin/cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/stylus-lookup/node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/supports-color": {
@@ -6245,6 +6685,17 @@
       "version": "0.0.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
     },
     "node_modules/ts-graphviz": {
       "version": "1.8.1",
@@ -6863,9 +7314,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw=="
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
+      "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg=="
     },
     "@dependents/detective-less": {
       "version": "4.1.0",
@@ -6907,6 +7358,11 @@
     "@iarna/toml": {
       "version": "2.2.5",
       "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "@ljharb/through": {
       "version": "2.3.11",
@@ -7172,6 +7628,57 @@
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "dev": true
+    },
+    "@vue/compiler-core": {
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.27.tgz",
+      "integrity": "sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==",
+      "requires": {
+        "@babel/parser": "^7.24.4",
+        "@vue/shared": "3.4.27",
+        "entities": "^4.5.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "@vue/compiler-dom": {
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
+      "integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
+      "requires": {
+        "@vue/compiler-core": "3.4.27",
+        "@vue/shared": "3.4.27"
+      }
+    },
+    "@vue/compiler-sfc": {
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.27.tgz",
+      "integrity": "sha512-nDwntUEADssW8e0rrmE0+OrONwmRlegDA1pD6QhVeXxjIytV03yDqTey9SBDiALsvAd5U4ZrEKbMyVXhX6mCGA==",
+      "requires": {
+        "@babel/parser": "^7.24.4",
+        "@vue/compiler-core": "3.4.27",
+        "@vue/compiler-dom": "3.4.27",
+        "@vue/compiler-ssr": "3.4.27",
+        "@vue/shared": "3.4.27",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.10",
+        "postcss": "^8.4.38",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "@vue/compiler-ssr": {
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.27.tgz",
+      "integrity": "sha512-CVRzSJIltzMG5FcidsW0jKNQnNRYC8bT21VegyMMtHmhW3UOI7knmUehzswXLrExDLE6lQCZdrhD4ogI7c+vuw==",
+      "requires": {
+        "@vue/compiler-dom": "3.4.27",
+        "@vue/shared": "3.4.27"
+      }
+    },
+    "@vue/shared": {
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.27.tgz",
+      "integrity": "sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA=="
     },
     "acorn": {
       "version": "7.4.1",
@@ -7785,20 +8292,225 @@
       }
     },
     "dependency-tree": {
-      "version": "10.0.9",
-      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-10.0.9.tgz",
-      "integrity": "sha512-dwc59FRIsht+HfnTVM0BCjJaEWxdq2YAvEDy4/Hn6CwS3CBWMtFnL3aZGAkQn3XCYxk/YcTDE4jX2Q7bFTwCjA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-11.0.1.tgz",
+      "integrity": "sha512-eCt7HSKIC9NxgIykG2DRq3Aewn9UhVS14MB3rEn6l/AsEI1FBg6ZGSlCU0SZ6Tjm2kkhj6/8c2pViinuyKELhg==",
       "requires": {
-        "commander": "^10.0.1",
-        "filing-cabinet": "^4.1.6",
-        "precinct": "^11.0.5",
-        "typescript": "^5.0.4"
+        "commander": "^12.0.0",
+        "filing-cabinet": "^5.0.1",
+        "precinct": "^12.0.2",
+        "typescript": "^5.4.5"
       },
       "dependencies": {
+        "@dependents/detective-less": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@dependents/detective-less/-/detective-less-5.0.0.tgz",
+          "integrity": "sha512-D/9dozteKcutI5OdxJd8rU+fL6XgaaRg60sPPJWkT33OCiRfkCu5wO5B/yXTaaL2e6EB0lcCBGe5E0XscZCvvQ==",
+          "requires": {
+            "gonzales-pe": "^4.3.0",
+            "node-source-walk": "^7.0.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "7.10.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.10.0.tgz",
+          "integrity": "sha512-7fNj+Ya35aNyhuqrA1E/VayQX9Elwr8NKZ4WueClR3KwJ7Xx9jcCdOrLW04h51de/+gNbyFMs+IDxh5xIwfbNg=="
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "7.10.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.10.0.tgz",
+          "integrity": "sha512-LXFnQJjL9XIcxeVfqmNj60YhatpRLt6UhdlFwAkjNc6jSUlK8zQOl1oktAP8PlWFzPQC1jny/8Bai3/HPuvN5g==",
+          "requires": {
+            "@typescript-eslint/types": "7.10.0",
+            "@typescript-eslint/visitor-keys": "7.10.0",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "minimatch": "^9.0.4",
+            "semver": "^7.6.0",
+            "ts-api-utils": "^1.3.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "7.10.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.10.0.tgz",
+          "integrity": "sha512-9ntIVgsi6gg6FIq9xjEO4VQJvwOqA3jaBFQJ/6TK5AvEup2+cECI6Fh7QiBxmfMHXU0V0J4RyPeOU1VDNzl9cg==",
+          "requires": {
+            "@typescript-eslint/types": "7.10.0",
+            "eslint-visitor-keys": "^3.4.3"
+          }
+        },
+        "ast-module-types": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-6.0.0.tgz",
+          "integrity": "sha512-LFRg7178Fw5R4FAEwZxVqiRI8IxSM+Ay2UBrHoCerXNme+kMMMfz7T3xDGV/c2fer87hcrtgJGsnSOfUrPK6ng=="
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
         "commander": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+          "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="
+        },
+        "detective-amd": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-6.0.0.tgz",
+          "integrity": "sha512-NTqfYfwNsW7AQltKSEaWR66hGkTeD52Kz3eRQ+nfkA9ZFZt3iifRCWh+yZ/m6t3H42JFwVFTrml/D64R2PAIOA==",
+          "requires": {
+            "ast-module-types": "^6.0.0",
+            "escodegen": "^2.1.0",
+            "get-amd-module-type": "^6.0.0",
+            "node-source-walk": "^7.0.0"
+          }
+        },
+        "detective-cjs": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-6.0.0.tgz",
+          "integrity": "sha512-R55jTS6Kkmy6ukdrbzY4x+I7KkXiuDPpFzUViFV/tm2PBGtTCjkh9ZmTuJc1SaziMHJOe636dtiZLEuzBL9drg==",
+          "requires": {
+            "ast-module-types": "^6.0.0",
+            "node-source-walk": "^7.0.0"
+          }
+        },
+        "detective-es6": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-5.0.0.tgz",
+          "integrity": "sha512-NGTnzjvgeMW1khUSEXCzPDoraLenWbUjCFjwxReH+Ir+P6LGjYtaBbAvITWn2H0VSC+eM7/9LFOTAkrta6hNYg==",
+          "requires": {
+            "node-source-walk": "^7.0.0"
+          }
+        },
+        "detective-postcss": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-7.0.0.tgz",
+          "integrity": "sha512-pSXA6dyqmBPBuERpoOKKTUUjQCZwZPLRbd1VdsTbt6W+m/+6ROl4BbE87yQBUtLoK7yX8pvXHdKyM/xNIW9F7A==",
+          "requires": {
+            "is-url": "^1.2.4",
+            "postcss-values-parser": "^6.0.2"
+          }
+        },
+        "detective-sass": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-6.0.0.tgz",
+          "integrity": "sha512-h5GCfFMkPm4ZUUfGHVPKNHKT8jV7cSmgK+s4dgQH4/dIUNh9/huR1fjEQrblOQNDalSU7k7g+tiW9LJ+nVEUhg==",
+          "requires": {
+            "gonzales-pe": "^4.3.0",
+            "node-source-walk": "^7.0.0"
+          }
+        },
+        "detective-scss": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-5.0.0.tgz",
+          "integrity": "sha512-Y64HyMqntdsCh1qAH7ci95dk0nnpA29g319w/5d/oYcHolcGUVJbIhOirOFjfN1KnMAXAFm5FIkZ4l2EKFGgxg==",
+          "requires": {
+            "gonzales-pe": "^4.3.0",
+            "node-source-walk": "^7.0.0"
+          }
+        },
+        "detective-stylus": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-5.0.0.tgz",
+          "integrity": "sha512-KMHOsPY6aq3196WteVhkY5FF+6Nnc/r7q741E+Gq+Ax9mhE2iwj8Hlw8pl+749hPDRDBHZ2WlgOjP+twIG61vQ=="
+        },
+        "detective-typescript": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-13.0.0.tgz",
+          "integrity": "sha512-tcMYfiFWoUejSbvSblw90NDt76/4mNftYCX0SMnVRYzSXv8Fvo06hi4JOPdNvVNxRtCAKg3MJ3cBJh+ygEMH+A==",
+          "requires": {
+            "@typescript-eslint/typescript-estree": "^7.6.0",
+            "ast-module-types": "^6.0.0",
+            "node-source-walk": "^7.0.0"
+          }
+        },
+        "detective-vue2": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/detective-vue2/-/detective-vue2-2.0.1.tgz",
+          "integrity": "sha512-EGHcIFCEPGO7MExgRZA8LqHQsKakjzrd96V358PV3WGFl+ibzNlYP/Msav43jBiCC5TpjWcy1FFUekrzXQM1Fg==",
+          "requires": {
+            "@vue/compiler-sfc": "^3.4.21",
+            "detective-es6": "^5.0.0",
+            "detective-sass": "^6.0.0",
+            "detective-scss": "^5.0.0",
+            "detective-stylus": "^5.0.0",
+            "detective-typescript": "^13.0.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+          "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="
+        },
+        "get-amd-module-type": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-6.0.0.tgz",
+          "integrity": "sha512-hFM7oivtlgJ3d6XWD6G47l8Wyh/C6vFw5G24Kk1Tbq85yh5gcM8Fne5/lFhiuxB+RT6+SI7I1ThB9lG4FBh3jw==",
+          "requires": {
+            "ast-module-types": "^6.0.0",
+            "node-source-walk": "^7.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+          "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "module-definition": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-6.0.0.tgz",
+          "integrity": "sha512-sEGP5nKEXU7fGSZUML/coJbrO+yQtxcppDAYWRE9ovWsTbFoUHB2qDUx564WUzDaBHXsD46JBbIK5WVTwCyu3w==",
+          "requires": {
+            "ast-module-types": "^6.0.0",
+            "node-source-walk": "^7.0.0"
+          }
+        },
+        "node-source-walk": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-7.0.0.tgz",
+          "integrity": "sha512-1uiY543L+N7Og4yswvlm5NCKgPKDEXd9AUR9Jh3gen6oOeBsesr6LqhXom1er3eRzSUcVRWXzhv8tSNrIfGHKw==",
+          "requires": {
+            "@babel/parser": "^7.24.4"
+          }
+        },
+        "precinct": {
+          "version": "12.1.1",
+          "resolved": "https://registry.npmjs.org/precinct/-/precinct-12.1.1.tgz",
+          "integrity": "sha512-Vmmtp0QdtM0Z5NzkRG09AgUgBwOpG0KW9KvG1vkltx+e2zrGCWbM5661f6lf8YjKbJhM39TICA6Wc36ZzX1PqQ==",
+          "requires": {
+            "@dependents/detective-less": "^5.0.0",
+            "commander": "^12.0.0",
+            "detective-amd": "^6.0.0",
+            "detective-cjs": "^6.0.0",
+            "detective-es6": "^5.0.0",
+            "detective-postcss": "^7.0.0",
+            "detective-sass": "^6.0.0",
+            "detective-scss": "^5.0.0",
+            "detective-stylus": "^5.0.0",
+            "detective-typescript": "^13.0.0",
+            "detective-vue2": "^2.0.0",
+            "module-definition": "^6.0.0",
+            "node-source-walk": "^7.0.0",
+            "postcss": "^8.4.38",
+            "typescript": "^5.4.5"
+          }
+        },
+        "semver": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+          "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
+        },
+        "typescript": {
+          "version": "5.4.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+          "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ=="
         }
       }
     },
@@ -7915,9 +8627,9 @@
       "dev": true
     },
     "enhanced-resolve": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
-      "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.1.tgz",
+      "integrity": "sha512-4U5pNsuDl0EhuZpq46M5xPslstkviJuhrdobaRDBk2Jy2KO37FDAJl4lb2KlNabxT0m4MTK2UHNrsAcphE8nyw==",
       "requires": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -7930,6 +8642,11 @@
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
       }
+    },
+    "entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -8161,6 +8878,11 @@
     "estraverse": {
       "version": "5.3.0"
     },
+    "estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+    },
     "esutils": {
       "version": "2.0.3"
     },
@@ -8279,28 +9001,54 @@
       }
     },
     "filing-cabinet": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-4.1.6.tgz",
-      "integrity": "sha512-C+HZbuQTER36sKzGtUhrAPAoK6+/PrrUhYDBQEh3kBRdsyEhkLbp1ML8S0+6e6gCUrUlid+XmubxJrhvL2g/Zw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-5.0.2.tgz",
+      "integrity": "sha512-RZlFj8lzyu6jqtFBeXNqUjjNG6xm+gwXue3T70pRxw1W40kJwlgq0PSWAmh0nAnn5DHuBIecLXk9+1VKS9ICXA==",
       "requires": {
         "app-module-path": "^2.2.0",
-        "commander": "^10.0.1",
-        "enhanced-resolve": "^5.14.1",
-        "is-relative-path": "^1.0.2",
-        "module-definition": "^5.0.1",
-        "module-lookup-amd": "^8.0.5",
-        "resolve": "^1.22.3",
-        "resolve-dependency-path": "^3.0.2",
-        "sass-lookup": "^5.0.1",
-        "stylus-lookup": "^5.0.1",
+        "commander": "^12.0.0",
+        "enhanced-resolve": "^5.16.0",
+        "module-definition": "^6.0.0",
+        "module-lookup-amd": "^9.0.1",
+        "resolve": "^1.22.8",
+        "resolve-dependency-path": "^4.0.0",
+        "sass-lookup": "^6.0.1",
+        "stylus-lookup": "^6.0.0",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.0.4"
+        "typescript": "^5.4.4"
       },
       "dependencies": {
+        "ast-module-types": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-6.0.0.tgz",
+          "integrity": "sha512-LFRg7178Fw5R4FAEwZxVqiRI8IxSM+Ay2UBrHoCerXNme+kMMMfz7T3xDGV/c2fer87hcrtgJGsnSOfUrPK6ng=="
+        },
         "commander": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+          "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="
+        },
+        "module-definition": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-6.0.0.tgz",
+          "integrity": "sha512-sEGP5nKEXU7fGSZUML/coJbrO+yQtxcppDAYWRE9ovWsTbFoUHB2qDUx564WUzDaBHXsD46JBbIK5WVTwCyu3w==",
+          "requires": {
+            "ast-module-types": "^6.0.0",
+            "node-source-walk": "^7.0.0"
+          }
+        },
+        "node-source-walk": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-7.0.0.tgz",
+          "integrity": "sha512-1uiY543L+N7Og4yswvlm5NCKgPKDEXd9AUR9Jh3gen6oOeBsesr6LqhXom1er3eRzSUcVRWXzhv8tSNrIfGHKw==",
+          "requires": {
+            "@babel/parser": "^7.24.4"
+          }
+        },
+        "typescript": {
+          "version": "5.4.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+          "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ=="
         }
       }
     },
@@ -8973,11 +9721,6 @@
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA=="
     },
-    "is-relative-path": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-relative-path/-/is-relative-path-1.0.2.tgz",
-      "integrity": "sha512-i1h+y50g+0hRbBD+dbnInl3JlJ702aar58snAeX+MxBAPvzXGej7sYoPMhlnykabt0ZzCJNBEyzMlekuQZN7fA=="
-    },
     "is-set": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
@@ -9247,6 +9990,14 @@
       "version": "3.2.0",
       "dev": true
     },
+    "magic-string": {
+      "version": "0.30.10",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      }
+    },
     "merge-stream": {
       "version": "2.0.0",
       "dev": true
@@ -9390,20 +10141,20 @@
       }
     },
     "module-lookup-amd": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-8.0.5.tgz",
-      "integrity": "sha512-vc3rYLjDo5Frjox8NZpiyLXsNWJ5BWshztc/5KSOMzpg9k5cHH652YsJ7VKKmtM4SvaxuE9RkrYGhiSjH3Ehow==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-9.0.1.tgz",
+      "integrity": "sha512-MFeZCK6j2k7fXlldyZ1FgA5goTmvLF0BCQKkxzapsvsPqhCM6NvanE0vy9x5HpY5ETF1yo+PCB9TZIow3PABYg==",
       "requires": {
-        "commander": "^10.0.1",
+        "commander": "^12.0.0",
         "glob": "^7.2.3",
         "requirejs": "^2.3.6",
         "requirejs-config-file": "^4.0.0"
       },
       "dependencies": {
         "commander": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+          "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="
         }
       }
     },
@@ -9713,19 +10464,19 @@
       "version": "8.0.0"
     },
     "postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "requires": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       },
       "dependencies": {
         "nanoid": {
-          "version": "3.3.6",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-          "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+          "version": "3.3.7",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+          "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
         }
       }
     },
@@ -10221,7 +10972,9 @@
       }
     },
     "resolve": {
-      "version": "1.22.4",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "requires": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -10233,9 +10986,9 @@
       "dev": true
     },
     "resolve-dependency-path": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/resolve-dependency-path/-/resolve-dependency-path-3.0.2.tgz",
-      "integrity": "sha512-Tz7zfjhLfsvR39ADOSk9us4421J/1ztVBo4rWUkF38hgHK5m0OCZ3NxFVpqHRkjctnwVa15igEUHFJp8MCS7vA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-dependency-path/-/resolve-dependency-path-4.0.0.tgz",
+      "integrity": "sha512-hlY1SybBGm5aYN3PC4rp15MzsJLM1w+MEA/4KU3UBPfz4S0lL3FL6mgv7JgaA8a+ZTeEQAiF1a1BuN2nkqiIlg=="
     },
     "resolve-from": {
       "version": "4.0.0",
@@ -10334,17 +11087,17 @@
       "dev": true
     },
     "sass-lookup": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-5.0.1.tgz",
-      "integrity": "sha512-t0X5PaizPc2H4+rCwszAqHZRtr4bugo4pgiCvrBFvIX0XFxnr29g77LJcpyj9A0DcKf7gXMLcgvRjsonYI6x4g==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-6.0.1.tgz",
+      "integrity": "sha512-nl9Wxbj9RjEJA5SSV0hSDoU2zYGtE+ANaDS4OFUR7nYrquvBFvPKZZtQHe3lvnxCcylEDV00KUijjdMTUElcVQ==",
       "requires": {
-        "commander": "^10.0.1"
+        "commander": "^12.0.0"
       },
       "dependencies": {
         "commander": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+          "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="
         }
       }
     },
@@ -10521,9 +11274,9 @@
       "devOptional": true
     },
     "source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg=="
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -10661,17 +11414,17 @@
       "dev": true
     },
     "stylus-lookup": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-5.0.1.tgz",
-      "integrity": "sha512-tLtJEd5AGvnVy4f9UHQMw4bkJJtaAcmo54N+ovQBjDY3DuWyK9Eltxzr5+KG0q4ew6v2EHyuWWNnHeiw/Eo7rQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-6.0.0.tgz",
+      "integrity": "sha512-RaWKxAvPnIXrdby+UWCr1WRfa+lrPMSJPySte4Q6a+rWyjeJyFOLJxr5GrAVfcMCsfVlCuzTAJ/ysYT8p8do7Q==",
       "requires": {
-        "commander": "^10.0.1"
+        "commander": "^12.0.0"
       },
       "dependencies": {
         "commander": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+          "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="
         }
       }
     },
@@ -10757,6 +11510,12 @@
     "tr46": {
       "version": "0.0.3",
       "dev": true
+    },
+    "ts-api-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+      "requires": {}
     },
     "ts-graphviz": {
       "version": "1.8.1"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "commander": "^7.2.0",
     "commondir": "^1.0.1",
     "debug": "^4.3.4",
-    "dependency-tree": "^10.0.9",
+    "dependency-tree": "^11.0.0",
     "ora": "^5.4.1",
     "pluralize": "^8.0.0",
     "precinct": "^11.0.5",


### PR DESCRIPTION
In this PR I updated to this release: https://github.com/dependents/node-dependency-tree/releases/tag/v11.0.0

Since the dependency dropped support for Node < 18, I did it here as well and adjusted the pipeline.