### PR TITLE
Add CI Docker builds.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+*.md
+.dockerignore
+.git
+.github
+.gitignore
+.editorconfig
+.eslintrc
+.nvmrc
+.release-it.json
+Dockerfile
+LICENSE
+test

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,35 @@
+name: docker
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
+      - name: environment
+        run: |
+          echo "IMAGE_TITLE=${{ secrets.REGISTRY }}/${{ secrets.REGISTRY_USER }}/${{ github.event.repository.name }}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+      - name: login
+        uses: docker/login-action@v4
+        with:
+          password: ${{ secrets.CR_PAT }}
+          registry: ${{ secrets.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USER }}
+      - name: build
+        uses: docker/build-push-action@v7
+        with:
+          cache-from: ref=${{ env.IMAGE_TITLE }}-amd64-cache:latest,type=registry
+          cache-to: ref=${{ env.IMAGE_TITLE }}-amd64-cache:latest,type=registry
+          load: true
+          platforms: linux/amd64
+          provenance: false
+          push: true
+          tags: ${{ env.IMAGE_TITLE }}:${{ env.IMAGE_TAG }}
+      - name: verify
+        run: docker run --rm ${{ env.IMAGE_TITLE }}:${{ env.IMAGE_TAG }} --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:26.7.0-alpine@sha256:aadf416b2cdce311a8811ba3f0608a61b77dbf997500e2eafe781b51f6a0b019
+
+RUN apk add --no-cache graphviz
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci --omit=dev \
+	&& npm cache clean --force
+
+COPY . .
+
+WORKDIR /code
+
+ENTRYPOINT ["node", "/app/bin/cli.js"]

--- a/README.md
+++ b/README.md
@@ -375,6 +375,13 @@ npm test
 npm run release
 ```
 
+# Docker
+Mount your code and pass a command you need.
+```sh
+docker run -v "$(pwd):/code" ghcr.io/pahen/madge:8.0.0 -h
+```
+Check [release tags](https://github.com/pahen/madge/tags) for image tags. Use a version without the leading "v".
+
 # FAQ
 
 ## Missing dependencies?


### PR DESCRIPTION
Build a Docker image for a tag and push it to a configured registry.

Essential secrets:
- CR_PAT - a classic Personal Access Token with "write:packages" scope
- REGISTRY = ghcr.io
- REGISTRY_USER = pahen